### PR TITLE
BITMAKER-1505-1: Configured BMC API URL as env variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -264,6 +264,7 @@ build-main-web:
       - $WEB_DIRECTORY/node_modules
   script:
     - cd $WEB_DIRECTORY
+    - echo "REACT_APP_API_BASE_URL=$BMC_API_URL" > .env
     - yarn install
     - yarn build
   artifacts:


### PR DESCRIPTION
#### Ticket url(s):
- https://tasks.bitmaker.dev/issues/1505

#### Description:
_Now bmc api url is not longer in repo, but configured as env variable to deploy in production._

#### Checklist:
- [x] Check that only one commit is added in the PR with the correct format
- [x] Rebase my branch