### PR TITLE
BITMAKER-1620: Fix Scrapy stats not being shown when using non-existing URLs

### DIFF
--- a/bitmaker-kafka/consumer.py
+++ b/bitmaker-kafka/consumer.py
@@ -44,9 +44,26 @@ def connect_kafka_consumer(topic_name):
         return _consumer
 
 
+# https://stackoverflow.com/questions/12397118/mongodb-dot-in-key-name
+def mongo_jsonify(item):
+    new_item = {}
+    if type(item) is dict:
+        for key, value in item.items():
+            new_key = key.replace(".", "\\u002e")
+            if type(value) is dict:
+                new_item[new_key] = mongo_jsonify(value)
+            elif type(value) is list:
+                new_item[new_key] = [mongo_jsonify(x) for x in value]
+            else:
+                new_item[new_key] = item[key]
+        return new_item
+    else:
+        return item
+
+
 def read_from_queue(client):
     while True:
-        item = item_queue.get()
+        item = mongo_jsonify(item_queue.get())
         try:
             if item["unique"] == "True":
                 client[item["database_name"]][item["collection_name"]].update_one(

--- a/bitmaker-web/src/components/JobDetailPage/index.tsx
+++ b/bitmaker-web/src/components/JobDetailPage/index.tsx
@@ -281,7 +281,7 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
                                                         {Object.keys(stats).map((key, idx) => {
                                                             return (
                                                                 <div key={idx}>
-                                                                    <b>{key}</b>: {stats[key]}
+                                                                    <b>{key.replace(/\\u002e/g, ".")}</b>: {stats[key]}
                                                                 </div>
                                                             );
                                                         })}


### PR DESCRIPTION
### Ticket URL:
- https://tasks.bitmaker.dev/issues/1620

### Description:
- The error was related to MongoDB, more specifically to `pymongo` not supporting dots `.` in the keys for the fields of an item.
- Replace dots `.` in item keys for their equivalent in Unicode and replace this value in the frontend to display it correctly.