### PR TITLE
BITMAKER-1862 Command line estela CLI to support UPDATE DataRetention fields

### DIFF
--- a/docs/estela-cli/commands/context.md
+++ b/docs/estela-cli/commands/context.md
@@ -13,8 +13,8 @@ Show your current context. This command will test your connection to your host a
 in the current directory as the active estela project if you are located in one.
 First, it will try to test your connection using the environment variables `ESTELA_API_HOST`,
 `ESTELA_USERNAME`, and `ESTELA_PASSWORD`. If any of these is not set, it will try to read your estela CLI configuration file
-`~/.estela.yaml`. If this file does not exist, the command will not work and you will have to 
-[estela login]({% link estela-cli/commands/login.md %}) first.
+`~/.estela.yaml`. If this file does not exist, the command will not work and you will have to log in 
+[estela login](https://github.com/bitmakerla/estela/blob/main/docs/estela-cli/commands/login.md) first.
 
 ## Usage
 
@@ -34,5 +34,5 @@ Active project: 7ba8ded9-9221-3a27-9c8d-afa59ead40c5.
 
 ## Related Commands
 
-- [estela login]({% link estela-cli/commands/login.md %})
-- [estela deploy]({% link estela-cli/commands/deploy.md %})
+- [estela login](https://github.com/bitmakerla/estela/blob/main/docs/estela-cli/commands/login.md)
+- [estela deploy](https://github.com/bitmakerla/estela/blob/main/docs/estela-cli/commands/deploy.md)

--- a/docs/estela-cli/commands/create_cronjob.md
+++ b/docs/estela-cli/commands/create_cronjob.md
@@ -28,6 +28,7 @@ $ estela create cronjob [OPTIONS] SCHEDULE SID [PID]
 |arg (-a)|Set spider cronjob argument NAME=VALUE (may be repeated)|
 |env (-e)|Set spider cronjob environment variable NAME=VALUE (may be repeated)|
 |tag (-t)|Set spider cronjob tag (may have multiple)|
+|day (-d)|Set number of days data stored (must be a number)|
 
 ## Examples
 
@@ -39,9 +40,12 @@ $ estela create cronjob -e STAGE=dev -a job_type=products
 # Create a cronjob with tag "test", which can be used to later retrieve the cronjob
 # by its tag.
 $ estela create job --tag test
+
+# Create a cronjob with 30 data expiry days
+$ estela create job --day 30
 ```
 
 ## Related Commands
 
-- [estela create job]({% link estela-cli/commands/create_job.md %})
-- [estela create project]({% link estela-cli/commands/create_project.md %})
+- [estela create job](https://github.com/bitmakerla/estela/blob/main/docs/estela-cli/commands/create_job.md)
+- [estela create project](https://github.com/bitmakerla/estela/blob/main/docs/estela-cli/commands/create_project.md)

--- a/docs/estela-cli/commands/create_job.md
+++ b/docs/estela-cli/commands/create_job.md
@@ -26,6 +26,7 @@ $ estela create job [OPTIONS] SID [PID]
 |arg (-a)|Set spider job argument NAME=VALUE (may be repeated)|
 |env (-e)|Set spider job environment variable NAME=VALUE (may be repeated)|
 |tag (-t)|Set spider cronjob tag (may have multiple)|
+|day (-d)|Set number of days data stored (must be a number)|
 
 ## Examples
 
@@ -37,6 +38,9 @@ $ estela create job -e STAGE=dev -e API_KEY=412dea23 -a job_type=products
 # Create a job with tag "test", which can be used to later retrieve the job
 # by its tag.
 $ estela create job --tag test
+
+# Create a cronjob with 30 data expiry days.
+$ estela create job --day 30
 ```
 
 ## Related Commands

--- a/docs/estela-cli/commands/update_cronjob.md
+++ b/docs/estela-cli/commands/update_cronjob.md
@@ -14,7 +14,7 @@ Update a cronjobs status and/or schedule.
 ## Usage
 
 ```bash
-$ estela update cronjob [OPTIONS] JID SID [PID]
+$ estela update cronjob [OPTIONS] CJID SID [PID]
 ```
 
 ## Options
@@ -26,6 +26,8 @@ $ estela update cronjob [OPTIONS] JID SID [PID]
 |PID (Required)|The project's id. It will use the currently active project by default.|
 |status|The cronjob's status. Possible values are: [ACTIVE\|DISABLED]|
 |schedule (-s)|The cronjob's crontab schedule.|
+|persistent (-p)|The cronjob's crontab schedule.|
+|days (-d)|The cronjob's crontab schedule.|
 
 ## Examples
 
@@ -37,9 +39,13 @@ cronjob/spider-cjob-51-7cf2fda9-5675-4f27-9d8c-faf54ead40c5 updated.
 # Update cronjob's schedule and disable the cronjob.
 $ estela update cronjob 51 101 --status DISABLED --schedule "0 21 * * *"
 cronjob/spider-cjob-51-7cf2fda9-5675-4f27-9d8c-faf54ead40c5 updated.
+
+# Update cronjob's data status and data expiry days.
+$ estela update cronjob 51 101 --persistent false --day 30
+cronjob/spider-cjob-51-7cf2fda9-5675-4f27-9d8c-faf54ead40c5 updated.
 ```
 
 ## Related Commands
 
-- [estela create cronjob]({% link estela-cli/commands/create_cronjob.md %})
-- [estela list cronjob]({% link estela-cli/commands/list_cronjob.md %})
+- [estela create cronjob](https://github.com/bitmakerla/estela/blob/main/docs/estela-cli/commands/create_cronjob.md)
+- [estela list cronjob](https://github.com/bitmakerla/estela/blob/main/docs/estela-cli/commands/list_cronjob.md)

--- a/docs/estela-cli/commands/update_job.md
+++ b/docs/estela-cli/commands/update_job.md
@@ -1,0 +1,43 @@
+---
+layout: page
+title: estela update cronjob
+parent: CLI Command Reference
+grand_parent: estela CLI
+---
+
+# estela update job
+
+## Description
+
+Update a job data status.
+
+## Usage
+
+```bash
+$ estela update job [OPTIONS] CJID SID [PID]
+```
+
+## Options
+
+|Option|Description|
+| ---- | --------- |
+|JID (Required)|The job's id.|
+|SID (Required)|The spider's id.|
+|PID (Required)|The project's id. It will use the currently active project by default.|
+|status|The cronjob's status. Possible values are: [ACTIVE\|DISABLED]|
+|schedule (-s)|The cronjob's crontab schedule.|
+|persistent (-p)|The cronjob's crontab schedule.|
+|days (-d)|The cronjob's crontab schedule.|
+
+## Examples
+
+```bash
+# Update job's data status and data expiry days.
+$ estela update job 51 101 --persistent false --day 30
+job/spider-job-51-7cf2fda9-5675-4f27-9d8c-faf54ead40c5 updated.
+```
+
+## Related Commands
+
+- [estela create job](https://github.com/bitmakerla/estela/blob/main/docs/estela-cli/commands/create_job.md)
+- [estela list job](https://github.com/bitmakerla/estela/blob/main/docs/estela-cli/commands/list_job.md)


### PR DESCRIPTION
There is not command that update DataStatus for jobs
Update Cronjob command doesn't allow data_expiry_days and data_status field, and it's required to create a job
estela CLI : https://github.com/bitmakerla/estela-cli/blob/master/estela_cli/