### PR TITLE
BITMAKER-1840 estela: Configure repository descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,28 @@
 <h1 align="center">estela</h1>
 
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![version](https://img.shields.io/badge/version-0.1-blue)](https://github.com/bitmakerla/estela)
-[![yarn-version](https://img.shields.io/badge/yarn-v1.22.19-blue)](https://yarnpkg.com)
-[![django-version](https://img.shields.io/badge/Django-v3.1.1-orange)](https://www.djangoproject.com)
-[![build](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/bitmakerla/estela/actions)
-![CI](https://github.com/eslint/eslint/workflows/CI/badge.svg)
-[![license](https://img.shields.io/badge/license-MIT-lightgrey)](https://github.com/bitmakerla/estela/blob/main/LICENSE.md)
-
+<div align="center">
+  <a href="https://github.com/bitmakerla/estela">
+    <img src="https://img.shields.io/badge/version-0.1-blue">
+  </a>
+  <a href="https://yarnpkg.com">
+    <img src="https://img.shields.io/badge/yarn-v1.22.19-blue">
+  </a>
+  <a href="https://www.djangoproject.com">
+    <img src="https://img.shields.io/badge/Django-v3.1.1-orange">
+  </a>
+  <a href="https://github.com/bitmakerla/estela/actions">
+    <img src="https://img.shields.io/badge/build-passing-brightgreen">
+  </a>
+  <a href="">
+    <img src="https://github.com/eslint/eslint/workflows/CI/badge.svg">
+  </a>
+  <a href="https://github.com/bitmakerla/estela/blob/main/LICENSE.md">
+    <img src="https://img.shields.io/badge/license-MIT-lightgrey">
+  </a>
+  <a href="https://github.com/psf/black">
+    <img src="https://img.shields.io/badge/code%20style-black-000000.svg">
+  </a>
+</div>
 
 <h4 align="center">
 <strong>estela</strong> is an elastic web scraping cluster running on Kubernetes. It provides mechanisms to deploy, run and scale

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![version](https://img.shields.io/badge/version-0.1-blue)](https://github.com/bitmakerla/estela)
 [![yarn-version](https://img.shields.io/badge/yarn-v1.22.19-blue)](https://yarnpkg.com)
+[![django-version](https://img.shields.io/badge/Django-v3.1.1-orange)](https://www.djangoproject.com)
 [![build](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/bitmakerla/estela/actions)
 ![CI](https://github.com/eslint/eslint/workflows/CI/badge.svg)
 [![licene](https://img.shields.io/badge/license-MIT-lightgrey)](https://github.com/bitmakerla/estela/blob/main/LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![django-version](https://img.shields.io/badge/Django-v3.1.1-orange)](https://www.djangoproject.com)
 [![build](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/bitmakerla/estela/actions)
 ![CI](https://github.com/eslint/eslint/workflows/CI/badge.svg)
-[![licene](https://img.shields.io/badge/license-MIT-lightgrey)](https://github.com/bitmakerla/estela/blob/main/LICENSE.md)
+[![license](https://img.shields.io/badge/license-MIT-lightgrey)](https://github.com/bitmakerla/estela/blob/main/LICENSE.md)
 
 
 <h4 align="center">
-<strong>estela</strong> is an elastic web scraping cluster running on <a>Kubernetes</a>. It provides mechanisms to deploy, run and scale
+<strong>estela</strong> is an elastic web scraping cluster running on Kubernetes. It provides mechanisms to deploy, run and scale
 web scraping spiders via a REST API and a web interface.
 </h4>
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,20 @@
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
+[![version](https://img.shields.io/badge/version-0.1-blue)](https://github.com/bitmakerla/estela)
+[![yarn-version](https://img.shields.io/badge/yarn-v1.22.19-blue)](https://yarnpkg.com)
+[![build](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/bitmakerla/estela/actions)
+![CI](https://github.com/eslint/eslint/workflows/CI/badge.svg)
+[![licene](https://img.shields.io/badge/license-MIT-lightgrey)](https://github.com/bitmakerla/estela/blob/main/LICENSE.md)
+
+
 <h4 align="center">
-estela is an elastic web scraping cluster running on Kubernetes. It provides mechanisms to deploy, run and scale
+<strong>estela</strong> is an elastic web scraping cluster running on <a>Kubernetes</a>. It provides mechanisms to deploy, run and scale
 web scraping spiders via a REST API and a web interface.
 </h4>
 
 <h3>Technologies</h3>
-<p align="left">
+<p align="center">
   <a href="https://www.docker.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/docker/docker-original-wordmark.svg" alt="docker" width="40" height="40"/> </a>
   <a href="https://www.python.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/> </a>
   <a href="https://reactjs.org/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original-wordmark.svg" alt="react" width="40" height="40"/> </a>
@@ -18,12 +25,12 @@ web scraping spiders via a REST API and a web interface.
 <h3>Project Structure</h3>
 
 The project consists of three main modules:
-- REST API (estela-api): built with the Django REST framework toolkit, it exposes several endpoints to manage projects, spiders, and
+- [**REST API**](https://github.com/bitmakerla/estela/tree/main/estela-api) : built with the Django REST framework toolkit, it exposes several endpoints to manage projects, spiders, and
     jobs. It uses Celery for task processing and takes care of deploying your Scrapy projects, among other things.
-- Queueing (queueing): estela needs a high-throughput, low-latency platform that controls real-time data feeds in a
+- [**Queueing**](https://github.com/bitmakerla/estela/tree/main/queueing) : estela needs a high-throughput, low-latency platform that controls real-time data feeds in a
     producer-consumer architecture. In this module, you will find a Kafka consumer used to collect and transport the
     information from the spider jobs into a database.
-- Web (estela-web): A web interface implemented with React and Typescript that lets you manage projects and spiders.
+- [**Web**](https://github.com/bitmakerla/estela/tree/main/estela-web) : A web interface implemented with React and Typescript that lets you manage projects and spiders.
 
 Each of these modules works independently of the rest and can be changed. Each module has a more detailed description
 in its corresponding directory.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <h1 align="center">estela</h1>
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-
 [![version](https://img.shields.io/badge/version-0.1-blue)](https://github.com/bitmakerla/estela)
 [![yarn-version](https://img.shields.io/badge/yarn-v1.22.19-blue)](https://yarnpkg.com)
 [![django-version](https://img.shields.io/badge/Django-v3.1.1-orange)](https://www.djangoproject.com)


### PR DESCRIPTION
We need to define the badges, links, description, and GitHub topics of estela repositories:
Consider all the github editable fields that offer a better understanding of the repositories