### PR TITLE
BITMAKER-1867-fix: Change branch name

### DIFF
--- a/.github/workflows/deploy-main-docs.yml
+++ b/.github/workflows/deploy-main-docs.yml
@@ -3,7 +3,7 @@ name: Build and Deploy the Docs
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - docs/**
   workflow_dispatch:


### PR DESCRIPTION
Hot fix: change the branch name of the gh workflow file
Ticket: https://tasks.bitmaker.dev/issues/1867