### PR TITLE
BITMAKER-1927 Improve "Delete data" in frontend

### DIFF
--- a/estela-web/src/components/JobDataListPage/index.tsx
+++ b/estela-web/src/components/JobDataListPage/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component, Fragment } from "react";
-import { Layout, List, Pagination, Typography, Button } from "antd";
+import { Layout, List, Pagination, Typography, Button, Modal, message } from "antd";
 import { RouteComponentProps } from "react-router-dom";
 
 import "./styles.scss";
@@ -20,6 +20,7 @@ import {
 
 const { Content } = Layout;
 const { Title } = Typography;
+const { confirm } = Modal;
 
 interface JobDataListPageState {
     data: unknown[];
@@ -74,6 +75,32 @@ export class JobDataListPage extends Component<RouteComponentProps<RouteParams>,
                 resourceNotAllowedNotification();
             },
         );
+    };
+
+    showConfirm = (): void => {
+        confirm({
+            title: "We are deleting your data from ...",
+            content: (
+                <>
+                    <p>
+                        Project: <strong>{this.projectId}</strong>
+                        <br />
+                        Spider: <strong>{this.spiderId}</strong>
+                        <br />
+                        Job: <strong>{this.jobId}</strong>
+                    </p>
+                    <p>Are you sure?</p>
+                </>
+            ),
+            onOk: () => {
+                console.log("Delete");
+                message.success("Your data is being deleted");
+                this.deleteSpiderJobData();
+            },
+            onCancel: () => {
+                console.log("Cancel action");
+            },
+        });
     };
 
     async getSpiderJobData(page: number): Promise<void> {
@@ -146,7 +173,7 @@ export class JobDataListPage extends Component<RouteComponentProps<RouteParams>,
                                         )}
                                         className="data-list"
                                     />
-                                    <Button danger className="stop-job" onClick={this.deleteSpiderJobData}>
+                                    <Button danger className="stop-job" onClick={this.showConfirm}>
                                         <div>Delete Job Data</div>
                                     </Button>
                                     <Pagination

--- a/estela-web/src/components/JobDataListPage/index.tsx
+++ b/estela-web/src/components/JobDataListPage/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component, Fragment } from "react";
-import { Layout, List, Pagination, Typography, Button, Modal, message } from "antd";
+import { Layout, List, Pagination, Typography, Button, Modal, message, Input } from "antd";
 import { RouteComponentProps } from "react-router-dom";
 
 import "./styles.scss";
@@ -26,6 +26,8 @@ interface JobDataListPageState {
     data: unknown[];
     current: number;
     count: number;
+    confirmationText: string;
+    isOkDisabled: boolean;
     loaded: boolean;
 }
 
@@ -42,6 +44,8 @@ export class JobDataListPage extends Component<RouteComponentProps<RouteParams>,
         data: [],
         count: 0,
         current: 0,
+        confirmationText: "",
+        isOkDisabled: true,
         loaded: false,
     };
     apiService = ApiService();
@@ -77,9 +81,25 @@ export class JobDataListPage extends Component<RouteComponentProps<RouteParams>,
         );
     };
 
+    onChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
+        this.setState({ confirmationText: e.target.value });
+    };
+
     showConfirm = (): void => {
         confirm({
             title: "We are deleting your data from ...",
+            okButtonProps: {
+                danger: true,
+                onClick: () => {
+                    if (this.state.confirmationText === this.projectId) {
+                        message.success("Your data is being deleted");
+                        this.deleteSpiderJobData();
+                        Modal.destroyAll();
+                    } else {
+                        message.error("Please write the correct ProjectId to delete");
+                    }
+                },
+            },
             content: (
                 <>
                     <p>
@@ -88,15 +108,11 @@ export class JobDataListPage extends Component<RouteComponentProps<RouteParams>,
                         Spider: <strong>{this.spiderId}</strong>
                         <br />
                         Job: <strong>{this.jobId}</strong>
+                        <Input placeholder="Write {pid} to delete" onChange={this.onChange} />
                     </p>
                     <p>Are you sure?</p>
                 </>
             ),
-            onOk: () => {
-                console.log("Delete");
-                message.success("Your data is being deleted");
-                this.deleteSpiderJobData();
-            },
             onCancel: () => {
                 console.log("Cancel action");
             },


### PR DESCRIPTION
# Description

"Delete data" does not return a notification until all data is deleted. This should say "we are deleting your data" and have a "are you sure?" modal.

Clicking "Delete data" does not ask for confirmation, which is dangerous. Also, the "data deleted" notification arrives after all data has been deleted. We should replace this with a "Deleting data..." notification.

# Issue

https://tasks.bitmaker.dev/issues/1927

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [x] New and existing tests pass locally with my changes.
- [x] If this change is a core feature, I have added thorough tests.
- [x] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [x] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
