### PR TITLE
BITMAKER-1931: Handle items that fail to be inserted to the DB

### DIFF
--- a/database_adapters/db_adapters.py
+++ b/database_adapters/db_adapters.py
@@ -10,9 +10,7 @@ class InsertionResponse:
     def __init__(self, ok, exception=None, need_upsert=False):
         self.ok = ok
         self.need_upsert = need_upsert
-        self.message = (
-            "Everything good! :)" if ok else "[{}]".format(exception.__class__.__name__)
-        )
+        self.error = None if (ok or exception is None) else exception.__class__.__name__
 
 
 class DatabaseInterface(metaclass=ABCMeta):

--- a/database_adapters/db_adapters.py
+++ b/database_adapters/db_adapters.py
@@ -3,7 +3,16 @@ import pymongo
 
 from abc import ABCMeta, abstractmethod
 from bson.json_util import loads
-from pymongo.errors import ConnectionFailure
+from pymongo.errors import ConnectionFailure, PyMongoError
+
+
+class InsertionResponse:
+    def __init__(self, ok, exception=None, need_upsert=False):
+        self.ok = ok
+        self.need_upsert = need_upsert
+        self.message = (
+            "Everything good! :)" if ok else "[{}]".format(exception.__class__.__name__)
+        )
 
 
 class DatabaseInterface(metaclass=ABCMeta):
@@ -93,19 +102,40 @@ class MongoAdapter(DatabaseInterface):
         return self.collection.estimated_document_count()
 
     def insert_one_to_unique_collection(self, database_name, collection_name, item):
-        return self.client[database_name][collection_name].update_one(
-            item, {"$set": item}, upsert=True
-        )
+        response = None
+        try:
+            self.client[database_name][collection_name].update_one(
+                item, {"$set": item}, upsert=True
+            )
+            response = InsertionResponse(True)
+        except PyMongoError as ex:
+            response = InsertionResponse(False, ex)
+        finally:
+            return response
 
     def insert_one_to_collection(self, database_name, collection_name, item):
-        return self.client[database_name][collection_name].insert_one(item)
+        response = None
+        try:
+            self.client[database_name][collection_name].insert_one(item)
+            response = InsertionResponse(True)
+        except PyMongoError as ex:
+            response = InsertionResponse(False, ex)
+        finally:
+            return response
 
     def insert_many_to_collection(
         self, database_name, collection_name, items, ordered=False
     ):
-        return self.client[database_name][collection_name].insert_many(
-            items, ordered=ordered
-        )
+        response = None
+        try:
+            self.client[database_name][collection_name].insert_many(
+                items, ordered=ordered
+            )
+            response = InsertionResponse(True)
+        except PyMongoError as ex:
+            response = InsertionResponse(False, ex, need_upsert=True)
+        finally:
+            return response
 
     def get_database_size(self, database_name, data_type):
         database = self.client[database_name]

--- a/queueing/Dockerfile
+++ b/queueing/Dockerfile
@@ -10,5 +10,6 @@ RUN pip install -r requirements/consumer.txt
 
 COPY queueing/consumer.py .
 COPY queueing/inserter.py .
+COPY queueing/utils.py .
 COPY queueing/config config
 COPY database_adapters/ ./database_adapters

--- a/queueing/consumer.py
+++ b/queueing/consumer.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import json
 import logging
 import threading
 import time

--- a/queueing/consumer.py
+++ b/queueing/consumer.py
@@ -34,7 +34,7 @@ def read_from_queue():
             current_timeout = (
                 QUEUE_MAX_TIMEOUT if next_timeout > QUEUE_MAX_TIMEOUT else next_timeout
             )
-            for identifier, inserter in inserters.items():
+            for inserter in inserters.values():
                 inserter.flush("empty queue")
             continue
 

--- a/queueing/inserter.py
+++ b/queueing/inserter.py
@@ -4,17 +4,23 @@ import sys
 import threading
 import time
 
+from copy import copy
+from utils import connect_kafka_producer
+
 
 BATCH_SIZE_THRESHOLD = int(os.getenv("BATCH_SIZE_THRESHOLD", "4096"))
 INSERT_TIME_THRESHOLD = int(os.getenv("INSERT_TIME_THRESHOLD", "5"))
 ACTIVITY_TIME_THRESHOLD = int(os.getenv("ACTIVITY_TIME_THRESHOLD", "600"))
 
+kafka_producer = connect_kafka_producer()
+
 
 class Inserter:
-    def __init__(self, client, database_name, collection_name, unique):
+    def __init__(self, client, database_name, collection_name, unique, topic):
         self.database_name = database_name
         self.collection_name = collection_name
         self.unique = unique
+        self.topic = topic
         self.identifier = "{}/{}".format(database_name, collection_name)
 
         self.__client = client
@@ -25,40 +31,58 @@ class Inserter:
 
         logging.info("New Inserter created for {}.".format(self.identifier))
 
-    def __insert_items(self):
+    def __handle_insertion_error(self, response, items):
+        logging.warning(
+            "The exception {} occured during the insertion of {} items in {}.".format(
+                response.message, len(items), self.identifier
+            )
+        )
+        for item in items:
+            if response.need_upsert:
+                item["need_upsert"] = "True"
+            kafka_producer.send(self.topic, value=item)
+
+    def __insert_items(self, reason=""):
+        items = [copy(item["payload"]) for item in self.__items]
         response = self.__client.insert_many_to_collection(
-            self.database_name, self.collection_name, self.__items
+            self.database_name, self.collection_name, items
         )
-        logging.debug(
-            "{} documents inserted in {}.".format(len(self.__items), self.identifier)
-        )
+        if response.ok:
+            logging.info(
+                "{} documents inserted [{}] in {}.".format(
+                    len(self.__items), reason, self.identifier
+                )
+            )
+        else:
+            self.__handle_insertion_error(response, self.__items)
         self.__items = []
-        return response
 
     def is_inactive(self):
         return time.time() - self.__last_activity > ACTIVITY_TIME_THRESHOLD
 
     def insert(self, item):
-        if self.unique:
-            self.__client.insert_one_to_unique_collection(
-                self.database_name, self.collection_name, item
+        if self.unique or item.get("need_upsert") is not None:
+            response = self.__client.insert_one_to_unique_collection(
+                self.database_name, self.collection_name, copy(item["payload"])
             )
-            logging.debug("1 document inserted in {}.".format(self.identifier))
+            if response.ok:
+                logging.debug("1 document inserted in {}.".format(self.identifier))
+            else:
+                self.__handle_insertion_error(response, [item])
         else:
             with self.__lock:
                 self.__items.append(item)
-                if (
-                    sys.getsizeof(self.__items) > BATCH_SIZE_THRESHOLD
-                    or time.time() - self.__last_insertion > INSERT_TIME_THRESHOLD
-                ):
-                    response = self.__insert_items()
+                if sys.getsizeof(self.__items) > BATCH_SIZE_THRESHOLD:
+                    self.__insert_items("size threshold")
+                elif time.time() - self.__last_insertion > INSERT_TIME_THRESHOLD:
+                    self.__insert_items("time threshold")
 
         self.__last_insertion = time.time()
         self.__last_activity = time.time()
 
-    def flush(self):
+    def flush(self, reason="unknown"):
         if not self.unique:
             with self.__lock:
                 if len(self.__items):
-                    response = self.__insert_items()
+                    self.__insert_items("{} flush".format(reason))
                     self.__last_activity = time.time()

--- a/queueing/inserter.py
+++ b/queueing/inserter.py
@@ -4,7 +4,6 @@ import sys
 import threading
 import time
 
-from copy import copy
 from utils import connect_kafka_producer
 
 

--- a/queueing/utils.py
+++ b/queueing/utils.py
@@ -1,0 +1,75 @@
+import os
+import json
+
+from kafka import KafkaConsumer, KafkaProducer
+
+
+def get_bootstrap_servers():
+    kafka_advertised_port = os.getenv("KAFKA_ADVERTISED_PORT", "9092")
+    kafka_advertised_listeners = os.getenv("KAFKA_ADVERTISED_LISTENERS").split(",")
+    bootstrap_servers = [
+        "{}:{}".format(kafka_advertised_listener, kafka_advertised_port)
+        for kafka_advertised_listener in kafka_advertised_listeners
+    ]
+    return bootstrap_servers
+
+
+def connect_kafka_consumer(topic_name, QUEUE_MAX_TIMEOUT):
+    _consumer = None
+    bootstrap_servers = get_bootstrap_servers()
+    try:
+        max_poll_interval_ms = (QUEUE_MAX_TIMEOUT + 1) * 1000
+        _consumer = KafkaConsumer(
+            topic_name,
+            bootstrap_servers=bootstrap_servers,
+            auto_offset_reset="earliest",
+            enable_auto_commit=True,
+            auto_commit_interval_ms=1000,
+            group_id="group_{}".format(topic_name),
+            api_version=(0, 10),
+            value_deserializer=lambda x: json.loads(x.decode("utf-8")),
+            max_poll_interval_ms=max_poll_interval_ms,
+            session_timeout_ms=max_poll_interval_ms,
+            request_timeout_ms=max_poll_interval_ms + 1,
+            connections_max_idle_ms=max_poll_interval_ms + 2,
+        )
+    except Exception as ex:
+        logging.error("Exception while connecting Kafka.")
+        logging.error(str(ex))
+    finally:
+        return _consumer
+
+
+def connect_kafka_producer():
+    _producer = None
+    bootstrap_servers = get_bootstrap_servers()
+    try:
+        _producer = KafkaProducer(
+            bootstrap_servers=bootstrap_servers,
+            value_serializer=lambda x: json.dumps(x).encode("utf-8"),
+            api_version=(0, 10),
+            acks=1,
+            retries=1,
+        )
+    except Exception as ex:
+        logging.error("Exception while connecting Kafka.")
+        logging.error(str(ex))
+    finally:
+        return _producer
+
+
+# https://stackoverflow.com/questions/12397118/mongodb-dot-in-key-name
+def jsonify(item):
+    new_item = {}
+    if type(item) is dict:
+        for key, value in item.items():
+            new_key = key.replace(".", "\\u002e")
+            if type(value) is dict:
+                new_item[new_key] = jsonify(value)
+            elif type(value) is list:
+                new_item[new_key] = [jsonify(x) for x in value]
+            else:
+                new_item[new_key] = item[key]
+        return new_item
+    else:
+        return item


### PR DESCRIPTION
# Description

_When the database fails while the Kafka consumers are inserting, the items that fail to be inserted are discarded and log the error inserting. This means we lose data, which cannot happen. Modify the consumer not to delete items that fail to be inserted_.

# Issue

* _https://tasks.bitmaker.dev/issues/1931_.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [x] New and existing tests pass locally with my changes.
- [x] If this change is a core feature, I have added thorough tests.
- [x] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [x] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
