### PR TITLE
BITMAKER-2118: Fix high memory usage of Kafka consumers

### DIFF
--- a/queueing/utils.py
+++ b/queueing/utils.py
@@ -18,7 +18,7 @@ def connect_kafka_consumer(topic_name, QUEUE_MAX_TIMEOUT):
     _consumer = None
     bootstrap_servers = get_bootstrap_servers()
     try:
-        max_poll_interval_ms = (QUEUE_MAX_TIMEOUT + 1) * 1000
+        max_poll_interval_ms = QUEUE_MAX_TIMEOUT * 1500
         _consumer = KafkaConsumer(
             topic_name,
             bootstrap_servers=bootstrap_servers,


### PR DESCRIPTION
# Description

_Fix the memory leak caused by kafka consumers_.

# Issue

* _https://tasks.bitmaker.dev/issues/2118_.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [x] New and existing tests pass locally with my changes.
- [x] If this change is a core feature, I have added thorough tests.
- [x] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [x] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
