### PR TITLE
BITMAKER-2277 estela-api: Query parameters are not received on Usage endpoint in estela api

### DIFF
--- a/estela-api/api/views/project.py
+++ b/estela-api/api/views/project.py
@@ -242,8 +242,8 @@ class ProjectViewSet(BaseViewSet, viewsets.ModelViewSet):
     def usage(self, request, *args, **kwargs):
         instance = self.get_object()
         project = Project.objects.get(pid=kwargs["pid"])
-        start_date = kwargs.get("start_date", datetime.today().replace(day=1))
-        end_date = kwargs.get("end_date", datetime.utcnow())
+        start_date = request.query_params.get("start_date", datetime.today().replace(day=1))
+        end_date = request.query_params.get("end_date", datetime.utcnow())
         serializer = UsageRecordSerializer(
             UsageRecord.objects.filter(
                 project=project, created_at__range=[start_date, end_date]


### PR DESCRIPTION
# Description

When a request is made to estela usage endpoint (https://estela.bitmaker.la/docs/estela/api/endpoints.html#tag/api/operation/api_projects_usage) query parameters start_date and end_date are not handled in Project/View.

# Issue

* https://tasks.bitmaker.dev/issues/2277.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [x] New and existing tests pass locally with my changes.
- [x] If this change is a core feature, I have added thorough tests.
- [x] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [x] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
