### PR TITLE
BITMAKER-2324: Add urls and keys from django external apps

### DIFF
--- a/docs/estela/installation/helm-variables.md
+++ b/docs/estela/installation/helm-variables.md
@@ -133,6 +133,8 @@ you have a deep understanding of estela.
 
 * _<DJANGO\_EXTERNAL\_APPS>_: List of Django external apps that will be installed and added to INSTALLED_APPS. To install them, you must create a file similar to estela/api/requirements/externalApps.txt.example and add the repositories of the applications that will be installed via pip.
 
+* _<EXTERNAL\_APP\_KEYS>_: List of keys to use inside Djando external apps.
+
 * _<EXTERNAL\_MIDDLEWARES>_: List of middleware that are generally found in Django external apps.
 
 #### Celery

--- a/estela-api/config/settings/base.py
+++ b/estela-api/config/settings/base.py
@@ -31,6 +31,7 @@ env = environ.Env(
     DJANGO_API_HOST=(str, "127.0.0.1"),
     DJANGO_ALLOWED_HOSTS=(str, ""),
     DJANGO_EXTERNAL_APPS=(str, ""),
+    EXTERNAL_APP_KEYS=(str, "dummy"),
     EXTERNAL_MIDDLEWARES=(str, ""),
     KAFKA_HOSTS=(str, "127.0.0.1"),
     KAFKA_PORT=(str, "dummy"),
@@ -71,6 +72,7 @@ ALLOWED_HOSTS = env("DJANGO_ALLOWED_HOSTS").split(",")
 
 
 DJANGO_EXTERNAL_APPS = [x for x in env("DJANGO_EXTERNAL_APPS").split(",") if x]
+EXTERNAL_APP_KEYS = [x for x in env("EXTERNAL_APP_KEYS").split(",") if x]
 EXTERNAL_MIDDLEWARES = [x for x in env("EXTERNAL_MIDDLEWARES").split(",") if x]
 
 

--- a/estela-api/config/urls.py
+++ b/estela-api/config/urls.py
@@ -14,9 +14,17 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+from django.conf import settings
 from django.urls import include, path
+
+django_external_apps_url = []
+for external_app in settings.DJANGO_EXTERNAL_APPS:
+    django_external_apps_url.append(
+        path(f"{external_app}/", include(f"{external_app}.urls"))
+    )
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("api.urls")),
 ]
+urlpatterns = urlpatterns + django_external_apps_url

--- a/installation/helm-chart/templates/API/api-secrets.yaml
+++ b/installation/helm-chart/templates/API/api-secrets.yaml
@@ -11,6 +11,7 @@ data:
   EMAIL_HOST_USER: {{ .Values.EMAIL_HOST_USER | b64enc }}
   EMAIL_HOST_PASSWORD: {{ .Values.EMAIL_HOST_PASSWORD | b64enc }}
   SECRET_KEY: {{ .Values.SECRET_KEY | b64enc }}
+  EXTERNAL_APP_KEYS: {{ .Values.EXTERNAL_APP_KEYS | b64enc }}
   {{- if .Values.AWS_ACCESS_KEY_ID }}
   AWS_ACCESS_KEY_ID: {{ .Values.AWS_ACCESS_KEY_ID | b64enc }}
   {{- end }}

--- a/installation/helm-chart/values.yaml.example
+++ b/installation/helm-chart/values.yaml.example
@@ -51,7 +51,8 @@ ENGINE: "" # kubernetes
 CREDENTIALS: "" # local
 CORS_ORIGIN_WHITELIST: ""
 DJANGO_API_HOST: dummy
-DJANGO_EXTERNAL_APPS: "" # "app1,app2,app3"
+DJANGO_EXTERNAL_APPS: "" # "app_1,app_2,..."
+EXTERNAL_APP_KEYS: "" # "key_1,key_2,..."
 EXTERNAL_MIDDLEWARES: "" # "app1.middlware,app2.middlware"
 
 # Celery


### PR DESCRIPTION
# Description

Modify estela to use features that require keys, urls,  etc, in Django external apps.

# Issue

* [_ID_](https://tasks.bitmaker.dev/issues/2324).

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [x] New and existing tests pass locally with my changes.
- [x] If this change is a core feature, I have added thorough tests.
- [x] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [x] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
