### PR TITLE
BITMAKER-3121 global stats frontend: hot fix in charts section

### DIFF
--- a/estela-api/api/views/stats.py
+++ b/estela-api/api/views/stats.py
@@ -221,8 +221,6 @@ class GlobalStatsViewSet(BaseViewSet, StatsForDashboardMixin, mixins.ListModelMi
             "{}-{}-job_stats".format(job.spider.sid, job.jid) for job in jobs_set
         ]
 
-        print("ids:", job_stats_ids)
-
         stats_set: List[dict] = spiderdata_db_client.get_jobs_set_stats(
             kwargs["pid"], job_stats_ids
         )

--- a/estela-api/core/tasks.py
+++ b/estela-api/core/tasks.py
@@ -289,9 +289,9 @@ def record_job_coverage_event(job_id):
 
         scraped_fields_count = sum(field_counts.values())
         coverage["total_items"] = total_items
-        coverage["total_items_coverage"] = 100 * (scraped_fields_count / (
-            total_items * len(field_counts)
-        ))
+        coverage["total_items_coverage"] = 100 * (
+            scraped_fields_count / (total_items * len(field_counts))
+        )
 
         job_stats_id = f"{sid}-{job.jid}-job_stats"
         if not spiderdata_db_client.update_document(

--- a/estela-web/src/components/JobDetailPage/index.tsx
+++ b/estela-web/src/components/JobDetailPage/index.tsx
@@ -207,7 +207,9 @@ class ItemsMetadata extends Component<ItemsMetadataProps> {
     parseMetadata = (): void => {
         this.metadata.splice(0, this.metadata.length);
         for (const key in this.item) {
-            this.metadata.push(this.typeDefinition(key, this.item[key]));
+            if (key !== "coverage") {
+                this.metadata.push(this.typeDefinition(key, this.item[key]));
+            }
         }
     };
 
@@ -469,7 +471,6 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
     handleSubmit = (): void => {
         const futureDate: Date = new Date();
         futureDate.setDate(futureDate.getDate() + this.state.newDataExpireDays);
-        console.log(this.state.newEnvVars);
         const requestData = {
             args: [...this.state.newArgs],
             envVars: [...this.state.newEnvVars],
@@ -1177,6 +1178,10 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
                             {Object.entries(stats).map(([statKey, stat], index: number) => {
                                 if (stat === null) {
                                     stat = "null";
+                                }
+
+                                if (statKey === "coverage") {
+                                    return <React.Fragment key={index} />;
                                 }
 
                                 if (index % 2) {

--- a/estela-web/src/components/ProjectDashboardPage/index.tsx
+++ b/estela-web/src/components/ProjectDashboardPage/index.tsx
@@ -499,7 +499,7 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                 <Divider className="bg-estela-black-low mb-5" />
                 <Content className="flow-root">
                     <Tabs
-                        className="float-right text-estela-black-medium text-xs md:text-sm"
+                        className="float-right w-full text-estela-black-medium text-xs md:text-sm"
                         defaultActiveKey={"optionTab"}
                         onChange={this.onStatsTabChange}
                         items={[
@@ -795,7 +795,7 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                 <Card bordered={false} className="bg-white rounded-lg">
                     <Space direction="vertical" className="w-full">
                         <div className="flex items-center justify-between">
-                            <Text className="text-base text-estela-black-medium break-words">&lt;&gt; HEALTH</Text>
+                            <Text className="text-base text-estela-black-medium break-words">HEALTH</Text>
                             <TooltipAnt
                                 placement="left"
                                 title="Average success rate of all jobs in the specified range + Total No. scraped items."

--- a/estela-web/src/components/ProjectDashboardPage/index.tsx
+++ b/estela-web/src/components/ProjectDashboardPage/index.tsx
@@ -121,7 +121,7 @@ const getCoverageDataset = (statsData: GlobalStats[]) => {
 const getSuccessRateDataset = (statsData: GlobalStats[]) => {
     return [
         {
-            label: "Success rate (percentage)",
+            label: "Job success rate (percentage)",
             data: statsData.map((statData) => statData.stats.successRate ?? 0),
             backgroundColor: "#32C3A4",
         },
@@ -236,7 +236,6 @@ interface ProjectDashboardPageState {
     current: number;
     loadedStats: boolean;
     globalStats: GlobalStats[];
-    focusedStatIndex: number;
     statOptionTab: StatType;
     statsStartDate: moment.Moment;
     statsEndDate: moment.Moment;
@@ -259,7 +258,6 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
         current: 0,
         loadedStats: false,
         globalStats: [],
-        focusedStatIndex: 0,
         statOptionTab: StatType.JOBS,
         statsStartDate: moment().subtract(7, "days").startOf("day"),
         statsEndDate: moment(),
@@ -424,6 +422,14 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                         },
                         y: {
                             stacked: true,
+                            min:
+                                statOptionTab === StatType.COVERAGE || statOptionTab === StatType.SUCCESS_RATE
+                                    ? 0
+                                    : undefined,
+                            max:
+                                statOptionTab === StatType.COVERAGE || statOptionTab === StatType.SUCCESS_RATE
+                                    ? 100
+                                    : undefined,
                         },
                     },
                 }}
@@ -529,7 +535,7 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                                 children: this.chartsSection(),
                             },
                             {
-                                label: "Success rate",
+                                label: "Job success rate",
                                 key: StatType.SUCCESS_RATE,
                                 children: this.chartsSection(),
                             },
@@ -551,55 +557,61 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
     };
 
     dataSection: () => JSX.Element = () => {
-        const { loadedStats, globalStats, focusedStatIndex } = this.state;
+        const { loadedStats, globalStats } = this.state;
 
         if (!loadedStats) {
             return (
-                <>
-                    <Row className="animate-pulse h-12 w-full grid grid-cols-4 md:grid-cols-6 lg:grid-cols-7 justify-items-center bg-estela-blue-low rounded-md" />
-                </>
+                <Row className="animate-pulse h-12 w-full grid grid-cols-4 md:grid-cols-6 lg:grid-cols-7 justify-items-center bg-estela-blue-low rounded-md" />
             );
         }
 
         if (loadedStats && globalStats.length === 0) {
             return <></>;
         }
+        console.log("Before: ", globalStats);
+        const accumulatedStat = {
+            totalJobs: globalStats.reduce((acc, curr) => acc + (curr.stats.jobs.totalJobs ?? 0), 0),
+            totalPages: globalStats.reduce((acc, curr) => acc + (curr.stats.pages.totalPages ?? 0), 0),
+            totalItems: globalStats.reduce((acc, curr) => acc + (curr.stats.itemsCount ?? 0), 0),
+            totalRuntime: globalStats.reduce((acc, curr) => acc + (curr.stats.runtime ?? 0), 0),
+            totalSuccessRate:
+                globalStats.reduce((acc, curr) => acc + (curr.stats.successRate ?? 0), 0) / globalStats.length,
+            totalCoverage:
+                globalStats.reduce((acc, curr) => acc + (curr.stats.coverage.totalItemsCoverage ?? 0), 0) /
+                globalStats.length,
+            totalLogs: globalStats.reduce((acc, curr) => acc + (curr.stats.logs.totalLogs ?? 0), 0),
+        };
 
-        const focusedStat: GlobalStats = globalStats[focusedStatIndex];
-
+        console.log("After: ", globalStats);
         return (
             <>
                 <Row className="grid grid-cols-4 md:grid-cols-6 lg:grid-cols-7 justify-items-center bg-estela-blue-low rounded-md">
                     <Col className="grid grid-cols-1 my-2">
-                        <p className="text-sm text-center text-black">{focusedStat.stats.jobs.totalJobs ?? 0}</p>
+                        <p className="text-sm text-center text-black">{accumulatedStat.totalJobs}</p>
                         <p className="text-sm text-center text-estela-black-medium">Jobs</p>
                     </Col>
                     <Col className="grid grid-cols-1 my-2">
-                        <p className="text-sm text-center text-black">{focusedStat.stats.pages.totalPages ?? 0}</p>
+                        <p className="text-sm text-center text-black">{accumulatedStat.totalPages}</p>
                         <p className="text-sm text-center text-estela-black-medium">Pages</p>
                     </Col>
                     <Col className="grid grid-cols-1 my-2">
-                        <p className="text-sm text-center text-black">{focusedStat.stats.itemsCount ?? 0}</p>
+                        <p className="text-sm text-center text-black">{accumulatedStat.totalItems}</p>
                         <p className="text-sm text-center text-estela-black-medium">Items</p>
                     </Col>
                     <Col className="grid grid-cols-1 my-2">
-                        <p className="text-sm text-center text-black">{(focusedStat.stats.runtime ?? 0).toFixed(2)}</p>
+                        <p className="text-sm text-center text-black">{accumulatedStat.totalRuntime.toFixed(2)}</p>
                         <p className="text-sm text-center text-estela-black-medium">Runtime</p>
                     </Col>
                     <Col className="grid grid-cols-1 my-2">
-                        <p className="text-sm text-center text-black">
-                            {(focusedStat.stats.successRate ?? 0).toFixed(2)}
-                        </p>
-                        <p className="text-sm text-center text-estela-black-medium">Success rate</p>
+                        <p className="text-sm text-center text-black">{accumulatedStat.totalSuccessRate.toFixed(2)}</p>
+                        <p className="text-sm text-center text-estela-black-medium">Job success rate</p>
                     </Col>
                     <Col className="grid grid-cols-1 my-2">
-                        <p className="text-sm text-center text-black">
-                            {(focusedStat.stats.coverage.totalItemsCoverage ?? 0).toFixed(2)}
-                        </p>
+                        <p className="text-sm text-center text-black">{accumulatedStat.totalCoverage.toFixed(2)}</p>
                         <p className="text-sm text-center text-estela-black-medium">Coverage</p>
                     </Col>
                     <Col className="grid grid-cols-1 my-2">
-                        <p className="text-sm text-center text-black">{focusedStat.stats.logs.totalLogs ?? 0}</p>
+                        <p className="text-sm text-center text-black">{accumulatedStat.totalLogs}</p>
                         <p className="text-sm text-center text-estela-black-medium">Logs</p>
                     </Col>
                 </Row>
@@ -621,22 +633,10 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                         <p className="text-sm text-center text-estela-black-full">RUNTIME</p>
                     </Col>
                     <Col className="my-2">
-                        <p className="text-sm text-center text-estela-black-full">S. RATE</p>
+                        <p className="text-sm text-center text-estela-black-full">JOB S. RATE</p>
                     </Col>
                 </Row>
-                <Collapse
-                    bordered={false}
-                    className="bg-white"
-                    onChange={(key: string | string[]) => {
-                        if (key && !Array.isArray(key)) {
-                            const { focusedStatIndex } = this.state;
-                            const index = parseInt(key, 10);
-                            index !== focusedStatIndex && this.setState({ focusedStatIndex: index });
-                        }
-                    }}
-                    ghost
-                    accordion
-                >
+                <Collapse bordered={false} className="bg-white" ghost accordion>
                     {globalStats.map((stat, index) => {
                         const dateString = stat.date.toISOString();
                         const totalJobs = stat.stats.jobs.totalJobs ?? 0;
@@ -647,12 +647,27 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                             errorJobs: totalJobs !== 0 ? (100 * (stat.stats.jobs.errorJobs ?? 0)) / totalJobs : 0,
                             unknownJobs: totalJobs !== 0 ? (100 * (stat.stats.jobs.unknownJobs ?? 0)) / totalJobs : 0,
                         };
+                        const jobsSizeArr = Object.values(jobsSize);
+                        const firstIndex = jobsSizeArr.findIndex((size) => size !== 0);
+                        const lastIndex =
+                            jobsSizeArr.length - jobsSizeArr.reverse().findIndex((size) => size !== 0) - 1;
+
                         const pagesSize = {
                             scrapedPages:
                                 totalPages !== 0 ? (100 * (stat.stats.pages.scrapedPages ?? 0)) / totalPages : 0,
                             missedPages:
                                 totalPages !== 0 ? (100 * (stat.stats.pages.missedPages ?? 0)) / totalPages : 0,
                         };
+                        if (pagesSize.scrapedPages !== 0 && pagesSize.missedPages !== 0) {
+                            const minimumRatio = 10;
+                            if (pagesSize.scrapedPages < minimumRatio) {
+                                pagesSize.scrapedPages = minimumRatio;
+                                pagesSize.missedPages = 100 - minimumRatio;
+                            } else if (pagesSize.missedPages < minimumRatio) {
+                                pagesSize.missedPages = minimumRatio;
+                                pagesSize.scrapedPages = 100 - minimumRatio;
+                            }
+                        }
                         const successRate = (stat.stats.successRate ?? 0).toFixed(2);
                         return (
                             <Panel
@@ -669,19 +684,27 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                                         <Col className="grid grid-cols-1 px-2">
                                             <div className="flex items-center h-2.5 justify-start">
                                                 <div
-                                                    className="h-full rounded bg-estela-complementary-green"
+                                                    className={`${firstIndex === 0 && "rounded-l"} ${
+                                                        lastIndex === 0 && "rounded-r"
+                                                    } h-full bg-estela-complementary-green`}
                                                     style={{ width: `${jobsSize.finishedJobs}%` }}
                                                 />
                                                 <div
-                                                    className="h-full rounded bg-estela-complementary-yellow"
+                                                    className={`${firstIndex === 1 && "rounded-l"} ${
+                                                        lastIndex === 1 && "rounded-r"
+                                                    } h-full bg-estela-complementary-yellow`}
                                                     style={{ width: `${jobsSize.runningJobs}%` }}
                                                 />
                                                 <div
-                                                    className="h-full rounded bg-estela-complementary-purple"
+                                                    className={`${firstIndex === 2 && "rounded-l"} ${
+                                                        lastIndex === 2 && "rounded-r"
+                                                    } h-full bg-estela-complementary-purple`}
                                                     style={{ width: `${jobsSize.errorJobs}%` }}
                                                 />
                                                 <div
-                                                    className="h-full rounded bg-estela-black-medium"
+                                                    className={`${firstIndex === 3 && "rounded-l"} ${
+                                                        lastIndex === 3 && "rounded-r"
+                                                    } h-full bg-estela-black-medium`}
                                                     style={{ width: `${jobsSize.unknownJobs}%` }}
                                                 />
                                             </div>
@@ -690,11 +713,15 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                                         <Col className="grid grid-cols-1 px-2">
                                             <div className="flex items-center h-2.5 justify-start">
                                                 <div
-                                                    className="h-full rounded bg-estela-complementary-green"
+                                                    className={`${pagesSize.scrapedPages > 0 && "rounded-l"} ${
+                                                        pagesSize.missedPages === 0 && "rounded-r"
+                                                    } h-full bg-estela-complementary-green`}
                                                     style={{ width: `${pagesSize.scrapedPages}%` }}
                                                 />
                                                 <div
-                                                    className="h-full rounded bg-estela-complementary-purple"
+                                                    className={`${pagesSize.missedPages > 0 && "rounded-r"} ${
+                                                        pagesSize.scrapedPages === 0 && "rounded-l"
+                                                    } h-full bg-estela-complementary-purple`}
                                                     style={{ width: `${pagesSize.missedPages}%` }}
                                                 />
                                             </div>
@@ -720,28 +747,28 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                                 }
                                 key={`${index}`}
                             >
-                                <Row className="grid grid-cols-6">
+                                <Row className="grid grid-cols-6 ml-8 gap-1">
                                     <Col className="col-start-2 grid grid-cols-1 content-start">
                                         <div className="flex items-center gap-1">
-                                            <div className="w-3 h-3 bg-estela-complementary-green" />
+                                            <div className="w-3 h-3 bg-estela-complementary-green rounded" />
                                             <span className="text-estela-black-full text-xs">
-                                                {stat.stats.jobs.totalJobs ?? 0} finished
+                                                {stat.stats.jobs.finishedJobs ?? 0} finished
                                             </span>
                                         </div>
                                         <div className="flex items-center gap-1">
-                                            <div className="w-3 h-3 bg-estela-complementary-yellow" />
+                                            <div className="w-3 h-3 bg-estela-complementary-yellow rounded" />
                                             <span className="text-estela-black-full text-xs">
                                                 {stat.stats.jobs.runningJobs ?? 0} running
                                             </span>
                                         </div>
                                         <div className="flex items-center gap-1">
-                                            <div className="w-3 h-3 bg-estela-complementary-purple" />
+                                            <div className="w-3 h-3 bg-estela-complementary-purple rounded" />
                                             <span className="text-estela-black-full text-xs">
                                                 {stat.stats.jobs.errorJobs ?? 0} error
                                             </span>
                                         </div>
                                         <div className="flex items-center gap-1">
-                                            <div className="w-3 h-3 bg-estela-black-medium" />
+                                            <div className="w-3 h-3 bg-estela-black-medium rounded" />
                                             <span className="text-estela-black-full text-xs">
                                                 {stat.stats.jobs.unknownJobs ?? 0} unknown
                                             </span>
@@ -749,13 +776,13 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                                     </Col>
                                     <Col className="grid grid-cols-1 content-start">
                                         <div className="flex items-center gap-1">
-                                            <div className="w-3 h-3 bg-estela-complementary-green" />
+                                            <div className="w-3 h-3 bg-estela-complementary-green rounded" />
                                             <span className="text-estela-black-full text-xs">
                                                 {stat.stats.pages.scrapedPages ?? 0} scraped
                                             </span>
                                         </div>
                                         <div className="flex items-center gap-1">
-                                            <div className="w-3 h-3 bg-estela-complementary-purple" />
+                                            <div className="w-3 h-3 bg-estela-complementary-purple rounded" />
                                             <span className="text-estela-black-full text-xs">
                                                 {stat.stats.pages.missedPages ?? 0} missed
                                             </span>
@@ -798,7 +825,7 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                             <Text className="text-base text-estela-black-medium break-words">HEALTH</Text>
                             <TooltipAnt
                                 placement="left"
-                                title="Average success rate of all jobs in the specified range + Total No. scraped items."
+                                title="Average job success rate of all dates in the specified range + Total No. scraped items."
                             >
                                 <Help className="w-4 h-4 stroke-estela-black-medium" />
                             </TooltipAnt>

--- a/estela-web/src/components/ProjectDashboardPage/index.tsx
+++ b/estela-web/src/components/ProjectDashboardPage/index.tsx
@@ -535,7 +535,7 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                                 children: this.chartsSection(),
                             },
                             {
-                                label: "Job success rate",
+                                label: "Job S. rate",
                                 key: StatType.SUCCESS_RATE,
                                 children: this.chartsSection(),
                             },


### PR DESCRIPTION
# Description
Some problems appeared in the revision of the UI mockups.
- Coverage bug
- Set full width of the chart.
- Test the backend for large periods of time queries.

# Issue

* https://tasks.bitmaker.dev/issues/3121.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [ ] New and existing tests pass locally with my changes.
- [ ] If this change is a core feature, I have added thorough tests.
- [ ] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [ ] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
