### PR TITLE
BITMAKER-3270 Hot Fix global stats: Fix hours format

### DIFF
--- a/estela-web/src/pages/JobDetailPage/index.tsx
+++ b/estela-web/src/pages/JobDetailPage/index.tsx
@@ -26,6 +26,7 @@ import { Link, RouteComponentProps } from "react-router-dom";
 import "./styles.scss";
 import history from "../../history";
 import { ApiService } from "../../services";
+import { BytesMetric, formatSecondsToHHMMSS, formatBytes } from "../../utils";
 import Copy from "../../assets/icons/copy.svg";
 import Pause from "../../assets/icons/pause.svg";
 import Add from "../../assets/icons/add.svg";
@@ -144,11 +145,6 @@ type ItemsMetadataProps = {
 
 interface MetadataField {
     field: string;
-    type: string;
-}
-
-interface BytesMetric {
-    quantity: number;
     type: string;
 }
 
@@ -625,22 +621,6 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
         );
     };
 
-    formatBytes = (bytes: number): BytesMetric => {
-        if (!+bytes) {
-            return {
-                quantity: 0,
-                type: "Bytes",
-            };
-        } else {
-            const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
-            const i = Math.floor(Math.log(bytes) / Math.log(1024));
-            return {
-                quantity: parseFloat((bytes / Math.pow(1024, i)).toFixed(2)),
-                type: `${sizes[i > sizes.length - 1 ? 3 : i]}`,
-            };
-        }
-    };
-
     chartConfigs = (bytes: BytesMetric): [number[], string[]] => {
         const dataChartProportions = [1, 0];
         const colorChartArray = ["#7DC932", "#F1F1F1"];
@@ -682,7 +662,7 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
             items,
             status,
         } = this.state;
-        const bandwidth: BytesMetric = this.formatBytes(Number(totalResponseBytes));
+        const bandwidth: BytesMetric = formatBytes(Number(totalResponseBytes));
         const [dataChartProportions, colorChartArray] = this.chartConfigs(bandwidth);
         const lifespanPercentage: number = Math.round(100 * (Math.log(lifespan ?? 1) / Math.log(3600)));
         const dataChart = {
@@ -941,13 +921,14 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
                         </Row>
                     </Card>
                     <Card className="w-full col-span-3 flex flex-col" style={{ borderRadius: "8px" }} bordered={false}>
-                        <Text className="py-2 m-2 text-estela-black-medium font-medium text-base">Processing Time</Text>
+                        <Text className="py-2 m-2 text-estela-black-medium font-medium text-base">
+                            Processing Time (HH:MM:SS)
+                        </Text>
                         <Row className="grid grid-cols-1 py-1 px-2 mt-3">
                             <Col>
                                 <Text className="font-bold text-estela-black-full text-lg">
-                                    {(lifespan ?? 0).toFixed(2)}
+                                    {formatSecondsToHHMMSS(lifespan ?? 0)}
                                 </Text>
-                                <Text className="text-estela-black-full text-base"> seg</Text>
                             </Col>
                             <Col>
                                 <Text className="text-estela-black-medium text-xs">this job</Text>

--- a/estela-web/src/pages/ProjectDashboardPage/index.tsx
+++ b/estela-web/src/pages/ProjectDashboardPage/index.tsx
@@ -47,7 +47,7 @@ import {
     ApiStatsJobsStatsRequest,
     GetJobsStats,
 } from "../../services/api";
-import { formatSecondsToHHMMSS, formatBytes } from "../../utils";
+import { BytesMetric, formatSecondsToHHMMSS, formatBytes } from "../../utils";
 import { resourceNotAllowedNotification, Spin } from "../../shared";
 import { UserContext, UserContextProps } from "../../context";
 import moment from "moment";
@@ -235,9 +235,9 @@ enum StatType {
 
 interface ProjectDashboardPageState {
     name: string;
-    network: number;
+    formattedNetwork: BytesMetric;
     processingTime: number;
-    storage: number;
+    formattedStorage: BytesMetric;
     projectUseLoaded: boolean;
     loaded: boolean;
     count: number;
@@ -259,9 +259,9 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
     PAGE_SIZE = 10;
     state: ProjectDashboardPageState = {
         name: "",
-        network: 0,
+        formattedNetwork: {},
         processingTime: 0,
-        storage: 0,
+        formattedStorage: {},
         loaded: false,
         projectUseLoaded: false,
         count: 0,
@@ -303,9 +303,11 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
             const time = parseFloat(response.processingTime ?? "0");
             this.setState({
                 projectUseLoaded: true,
-                network: response.networkUsage,
+                formattedNetwork: formatBytes(response.networkUsage),
                 processingTime: Math.round(time * 100) / 100,
-                storage: response.itemsDataSize + response.requestsDataSize + response.logsDataSize,
+                formattedStorage: formatBytes(
+                    response.itemsDataSize + response.requestsDataSize + response.logsDataSize,
+                ),
                 loaded: true,
             });
         });
@@ -919,7 +921,7 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
     };
 
     projectUsageSection: () => JSX.Element = () => {
-        const { projectUseLoaded, network, processingTime, storage, loadedStats } = this.state;
+        const { projectUseLoaded, formattedNetwork, processingTime, formattedStorage, loadedStats } = this.state;
 
         const averageSuccessRates = this.calcAverageSuccessRate();
         const dataChart = {
@@ -1005,13 +1007,13 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                                 <div className="flex items-center justify-between space-x-4">
                                     <Text className="text-sm text-estela-black-medium break-words">Bandwidth</Text>
                                     <Text className="text-base text-estela-black-full break-words">
-                                        {formatBytes(network)}
+                                        {formattedNetwork.quantity} {formattedNetwork.type}
                                     </Text>
                                 </div>
                                 <div className="flex items-center justify-between space-x-4">
                                     <Text className="text-sm text-estela-black-medium break-words">Storage</Text>
                                     <Text className="text-base text-estela-black-full break-words">
-                                        {formatBytes(storage)}
+                                        {formattedStorage.quantity} {formattedStorage.type}
                                     </Text>
                                 </div>
                             </div>

--- a/estela-web/src/pages/ProjectDashboardPage/index.tsx
+++ b/estela-web/src/pages/ProjectDashboardPage/index.tsx
@@ -47,6 +47,7 @@ import {
     ApiStatsJobsStatsRequest,
     GetJobsStats,
 } from "../../services/api";
+import { formatSecondsToHHMMSS, formatBytes } from "../../utils";
 import { resourceNotAllowedNotification, Spin } from "../../shared";
 import { UserContext, UserContextProps } from "../../context";
 import moment from "moment";
@@ -367,20 +368,6 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
         });
     };
 
-    formatTime = (time: number): string => {
-        return moment().startOf("day").seconds(time).format("HH:mm:ss");
-    };
-
-    formatBytes = (bytes: number): string => {
-        if (!+bytes) {
-            return "0 Bytes";
-        } else {
-            const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
-            const i = Math.floor(Math.log(bytes) / Math.log(1024));
-            return `${parseFloat((bytes / Math.pow(1024, i)).toFixed(2))} ${sizes[i]}`;
-        }
-    };
-
     calcAverageSuccessRate = (): number => {
         const { globalStats } = this.state;
         if (globalStats.length === 0) return 0;
@@ -553,7 +540,7 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                                 children: this.chartsSection(),
                             },
                             {
-                                label: "Success rate",
+                                label: "Job Success rate",
                                 key: StatType.SUCCESS_RATE,
                                 children: this.chartsSection(),
                             },
@@ -670,7 +657,7 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                 align: "center",
                 render: (_, { jobStats }): ReactElement => {
                     let runtime = "no data";
-                    if (jobStats.stats) runtime = this.formatTime(jobStats.stats.runtime ?? 0);
+                    if (jobStats.stats) runtime = formatSecondsToHHMMSS(jobStats.stats.runtime ?? 0);
                     return <span className="text-xs text-estela-black-medium">{runtime}</span>;
                 },
             },
@@ -746,7 +733,7 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                     </Col>
                     <Col className="grid grid-cols-1 my-2">
                         <p className="text-sm text-center text-black">
-                            {this.formatTime(accumulatedStat.totalRuntime)}
+                            {formatSecondsToHHMMSS(accumulatedStat.totalRuntime)}
                         </p>
                         <p className="text-sm text-center text-estela-black-medium">Runtime</p>
                     </Col>
@@ -776,7 +763,7 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                         <p className="text-sm text-center text-estela-black-full">RUNTIME</p>
                     </Col>
                     <Col className="my-2">
-                        <p className="text-sm text-center text-estela-black-full">SUCCESS</p>
+                        <p className="text-sm text-center text-estela-black-full">JOB SUCCESS RATE</p>
                     </Col>
                 </Row>
                 <Collapse
@@ -902,7 +889,7 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                                         </Col>
                                         <Col className="m-auto">
                                             <p className="text-estela-black-full">
-                                                {this.formatTime(stat.stats.runtime ?? 0)}
+                                                {formatSecondsToHHMMSS(stat.stats.runtime ?? 0)}
                                             </p>
                                         </Col>
                                         <Col className="m-auto">
@@ -1012,19 +999,19 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                                         Processing time
                                     </Text>
                                     <Text className="text-base text-estela-black-full break-words">
-                                        {this.formatTime(processingTime)}
+                                        {formatSecondsToHHMMSS(processingTime)}
                                     </Text>
                                 </div>
                                 <div className="flex items-center justify-between space-x-4">
                                     <Text className="text-sm text-estela-black-medium break-words">Bandwidth</Text>
                                     <Text className="text-base text-estela-black-full break-words">
-                                        {this.formatBytes(network)}
+                                        {formatBytes(network)}
                                     </Text>
                                 </div>
                                 <div className="flex items-center justify-between space-x-4">
                                     <Text className="text-sm text-estela-black-medium break-words">Storage</Text>
                                     <Text className="text-base text-estela-black-full break-words">
-                                        {this.formatBytes(storage)}
+                                        {formatBytes(storage)}
                                     </Text>
                                 </div>
                             </div>

--- a/estela-web/src/pages/ProjectJobListPage/index.tsx
+++ b/estela-web/src/pages/ProjectJobListPage/index.tsx
@@ -58,7 +58,6 @@ interface ProjectJobListPageState {
     runningJobs: SpiderJobData[];
     completedJobs: SpiderJobData[];
     errorJobs: SpiderJobData[];
-    modal: boolean;
     loaded: boolean;
     count: number;
     current: number;
@@ -85,7 +84,6 @@ export class ProjectJobListPage extends Component<RouteComponentProps<RouteParam
         completedJobs: [],
         errorJobs: [],
         loading: false,
-        modal: this.LocationState ? this.LocationState.open : false,
         tableStatus: new Array<boolean>(4).fill(true),
         loaded: false,
         count: 0,

--- a/estela-web/src/pages/SettingsPasswordPage/index.tsx
+++ b/estela-web/src/pages/SettingsPasswordPage/index.tsx
@@ -73,8 +73,8 @@ export class SettingsPasswordPage extends Component<unknown, PasswordSettingsPag
                     this.setState({ loadingSendRequest: false, successfullyChanged: true, showPasswordModal: false });
                 }
             },
-            (error) => {
-                console.error(error);
+            () => {
+                // Error
                 wrongPasswordNotification();
                 this.oldPasswordForm.current?.resetFields();
                 this.setState({ loadingSendRequest: false });

--- a/estela-web/src/pages/SpiderDetailPage/index.tsx
+++ b/estela-web/src/pages/SpiderDetailPage/index.tsx
@@ -18,10 +18,9 @@ import type { RadioChangeEvent } from "antd";
 import { RouteComponentProps, Link } from "react-router-dom";
 
 import "./styles.scss";
-import history from "../../history";
+import CronjobCreateModal from "../CronjobCreateModal";
+import JobCreateModal from "../JobCreateModal";
 import { ApiService } from "../../services";
-import Add from "../../assets/icons/add.svg";
-import Play from "../../assets/icons/play.svg";
 import Setting from "../../assets/icons/setting.svg";
 import Filter from "../../assets/icons/filter.svg";
 
@@ -775,31 +774,18 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
                                         <Text className="text-estela-black-medium text-xl">{name}</Text>
                                     </Col>
                                     <Col className="float-right">
-                                        <Button
-                                            onClick={() => {
-                                                history.push(`/projects/${this.projectId}/cronjobs`);
-                                            }}
-                                            icon={<Add className="mr-2" width={19} />}
-                                            size="large"
-                                            className="flex items-center stroke-white border-estela hover:stroke-estela bg-estela text-white hover:text-estela text-sm hover:border-estela rounded-md"
-                                        >
-                                            Schedule job
-                                        </Button>
+                                        <CronjobCreateModal
+                                            openModal={false}
+                                            spider={this.state.spider}
+                                            projectId={this.projectId}
+                                        />
                                     </Col>
                                     <Col className="float-right">
-                                        <Button
-                                            onClick={() => {
-                                                history.push(`/projects/${this.projectId}/jobs`, {
-                                                    open: true,
-                                                    spider: this.state.spider,
-                                                });
-                                            }}
-                                            icon={<Play className="mr-2" width={19} />}
-                                            size="large"
-                                            className="flex items-center stroke-white border-estela hover:stroke-estela bg-estela text-white hover:text-estela text-sm hover:border-estela rounded-md"
-                                        >
-                                            Run new job
-                                        </Button>
+                                        <JobCreateModal
+                                            openModal={false}
+                                            spider={this.state.spider}
+                                            projectId={this.projectId}
+                                        />
                                     </Col>
                                 </Row>
                                 <Tabs

--- a/estela-web/src/utils.ts
+++ b/estela-web/src/utils.ts
@@ -20,6 +20,27 @@ export function convertDateToString(date: Date | undefined): string {
     return "";
 }
 
+export function formatSecondsToHHMMSS(seconds: number): string {
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const remainingSeconds = Math.round(seconds % 60);
+    const formattedTime = [
+        hours.toString().padStart(2, "0"),
+        minutes.toString().padStart(2, "0"),
+        remainingSeconds.toString().padStart(2, "0"),
+    ].join(":");
+    return formattedTime;
+}
+
+export function formatBytes(bytes: number): string {
+    if (!+bytes) {
+        return "0 Bytes";
+    }
+    const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    return `${parseFloat((bytes / Math.pow(1024, i)).toFixed(2))} ${sizes[i]}`;
+}
+
 export function handleInvalidDataError(error: unknown): void {
     if (error instanceof Response) {
         error

--- a/estela-web/src/utils.ts
+++ b/estela-web/src/utils.ts
@@ -1,5 +1,10 @@
 import { invalidDataNotification } from "./shared";
 
+interface BytesMetric {
+    quantity: number;
+    type: string;
+}
+
 function completeDateInfo(data: number): string {
     if (data < 10) {
         return `0${data}`;
@@ -32,13 +37,20 @@ export function formatSecondsToHHMMSS(seconds: number): string {
     return formattedTime;
 }
 
-export function formatBytes(bytes: number): string {
+export function formatBytes(bytes: number): BytesMetric {
     if (!+bytes) {
-        return "0 Bytes";
+        return {
+            quantity: 0,
+            type: "Bytes",
+        };
     }
+
     const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
     const i = Math.floor(Math.log(bytes) / Math.log(1024));
-    return `${parseFloat((bytes / Math.pow(1024, i)).toFixed(2))} ${sizes[i]}`;
+    return {
+        quantity: parseFloat((bytes / Math.pow(1024, i)).toFixed(2)),
+        type: `${sizes[i > sizes.length - 1 ? 3 : i]}`,
+    };
 }
 
 export function handleInvalidDataError(error: unknown): void {


### PR DESCRIPTION
# Description

Issue on the processing time in the project dashboard, when entering an amount of seconds greater than one day it parses it wrong. E.g. in the attached image processing time in seconds are 121992.813125 this should be 33:53:12, but in frontend is 9:53:12.
Task:
* Fix the issue.

Completion Criteria:
* The time format is correct.

# Issue

* https://tasks.bitmaker.dev/issues/3270.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [x] New and existing tests pass locally with my changes.
- [x] If this change is a core feature, I have added thorough tests.
- [x] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [x] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
