### PR TITLE
Fix data pagination for requests and logs

### DIFF
--- a/estela-web/src/pages/JobDataPage/index.tsx
+++ b/estela-web/src/pages/JobDataPage/index.tsx
@@ -317,7 +317,7 @@ export function JobRequestsData({ projectId, spiderId, jobId }: JobsDataProps) {
 
     const onRequestsPageChange = async (page: number): Promise<void> => {
         setLoaded(false);
-        await getData("requests", page, projectId, spiderId, jobId, page).then((response) => {
+        await getData("requests", page, projectId, spiderId, jobId).then((response) => {
             let data: Dictionary[] = [];
             if (response.results?.length) {
                 const safe_data: unknown[] = response.results ?? [];
@@ -532,7 +532,7 @@ export function JobLogsData({ projectId, spiderId, jobId }: JobsDataProps) {
 
     const onLogsPageChange = async (page: number): Promise<void> => {
         setLoaded(false);
-        await getData("logs", page, projectId, spiderId, jobId, page).then((response) => {
+        await getData("logs", page, projectId, spiderId, jobId).then((response) => {
             let data: Dictionary[] = [];
             if (response.results?.length) {
                 const safe_data: unknown[] = response.results ?? [];


### PR DESCRIPTION
# Description

When manually entering the page we want for requests or logs, it also sets the page size to that value. So, when entering `page: 3`, it was also setting `pageSize: 3`, and we would only get 3 results of the specified page.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [x] New and existing tests pass locally with my changes.
- [x] If this change is a core feature, I have added thorough tests.
- [x] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [x] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
