### PR TITLE
BITMAKER-3361: Improve user experience on first interaction with BMC

### DIFF
--- a/estela-api/api/serializers/cronjob.py
+++ b/estela-api/api/serializers/cronjob.py
@@ -32,6 +32,7 @@ class SpiderCronJobSerializer(serializers.ModelSerializer):
     name = serializers.CharField(
         required=False, read_only=True, help_text="Unique cron job name."
     )
+    spider = serializers.SerializerMethodField("get_spider")
 
     class Meta:
         model = SpiderCronJob
@@ -49,6 +50,9 @@ class SpiderCronJobSerializer(serializers.ModelSerializer):
             "data_status",
             "data_expiry_days",
         )
+
+    def get_spider(self, instance):
+        return {"sid": instance.spider.sid, "name": instance.spider.name}
 
 
 class SpiderCronJobCreateSerializer(serializers.ModelSerializer):

--- a/estela-api/api/serializers/job.py
+++ b/estela-api/api/serializers/job.py
@@ -28,6 +28,7 @@ class SpiderJobSerializer(serializers.ModelSerializer):
     job_status = serializers.CharField(
         required=False, read_only=True, help_text="Current job status."
     )
+    spider = serializers.SerializerMethodField("get_spider")
 
     class Meta:
         model = SpiderJob
@@ -48,6 +49,9 @@ class SpiderJobSerializer(serializers.ModelSerializer):
             "data_expiry_days",
             "data_status",
         )
+
+    def get_spider(self, instance):
+        return {"sid": instance.spider.sid, "name": instance.spider.name}
 
 
 class SpiderJobCreateSerializer(serializers.ModelSerializer):

--- a/estela-api/api/views/auth.py
+++ b/estela-api/api/views/auth.py
@@ -119,7 +119,7 @@ class AuthAPIViewSet(viewsets.GenericViewSet):
             )
             email.send()
             return redirect(
-                settings.CORS_ORIGIN_WHITELIST[0],
+                "".join([settings.CORS_ORIGIN_WHITELIST[0], "/activatedAccount"]),
                 {
                     "message": "Thank you for your email confirmation. You can now log in to your account."
                 },

--- a/estela-api/docs/api.yaml
+++ b/estela-api/docs/api.yaml
@@ -1750,8 +1750,6 @@ definitions:
         minLength: 1
   SpiderCronJob:
     description: Project Cronjobs.
-    required:
-      - spider
     type: object
     properties:
       cjid:
@@ -1761,8 +1759,8 @@ definitions:
         readOnly: true
       spider:
         title: Spider
-        description: Spider sid.
-        type: integer
+        type: string
+        readOnly: true
       created:
         title: Created
         description: Cron job creation date.
@@ -2022,8 +2020,6 @@ definitions:
           minLength: 1
   SpiderJob:
     description: Project jobs.
-    required:
-      - spider
     type: object
     properties:
       jid:
@@ -2033,8 +2029,8 @@ definitions:
         readOnly: true
       spider:
         title: Spider
-        description: Spider sid.
-        type: integer
+        type: string
+        readOnly: true
       created:
         title: Created
         description: Job creation date.
@@ -2338,7 +2334,7 @@ definitions:
         minimum: 0
       data_status:
         title: Data status
-        description: Data status.
+        description: Job data status.
         type: string
         enum:
           - PERSISTENT
@@ -2346,11 +2342,8 @@ definitions:
           - DELETED
       data_expiry_days:
         title: Data expiry days
-        description: Days before data is deleted.
+        description: Job data expiry days.
         type: integer
-        maximum: 65535
-        minimum: 0
-        x-nullable: true
   DeleteJobData:
     required:
       - count

--- a/estela-web/src/components/EstelaBanner/index.tsx
+++ b/estela-web/src/components/EstelaBanner/index.tsx
@@ -1,0 +1,30 @@
+import React, { Component } from "react";
+import { Space, Typography, Layout } from "antd";
+
+import Bitmaker from "../../assets/logo/bitmaker.svg";
+import Estela from "../../assets/icons/estela.svg";
+
+const { Content } = Layout;
+const { Text } = Typography;
+
+export class EstelaBanner extends Component<unknown> {
+    render() {
+        return (
+            <Content className="flex h-fit lg:ml-36 sm:h-fit md:h-full lg:h-full m-auto justify-center items-center p-14 sm:p-auto md:p-auto">
+                <div>
+                    <Estela className="w-48 h-24" />
+                    <p className="text-5xl font-bold mt-4">
+                        Stable, reliable and <span className="text-estela">open source</span>.
+                    </p>
+                    <p className="text-3xl font-normal py-6 sm:p-auto">
+                        Scrape <span className="text-estela">when you want it</span>.
+                    </p>
+                    <Space>
+                        <Text className="text-sm font-normal">Powered by&nbsp;</Text>
+                        <Bitmaker className="w-40 h-40" />
+                    </Space>
+                </div>
+            </Content>
+        );
+    }
+}

--- a/estela-web/src/components/index.ts
+++ b/estela-web/src/components/index.ts
@@ -1,3 +1,4 @@
 export { ChartsSection } from "./Stats/ChartsSection";
 export { StatsTableSection } from "./Stats/StatsTableSection";
 export { HeaderSection } from "./Stats/HeaderSection";
+export { EstelaBanner } from "./EstelaBanner";

--- a/estela-web/src/defaultComponents/CustomerVerifier/index.tsx
+++ b/estela-web/src/defaultComponents/CustomerVerifier/index.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const CustomerVerifier: React.FC = () => {
+    return <></>;
+};
+
+export default CustomerVerifier;

--- a/estela-web/src/defaultComponents/CustomerVerifier/index.tsx
+++ b/estela-web/src/defaultComponents/CustomerVerifier/index.tsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const CustomerVerifier: React.FC = () => {
-    return <></>;
-};
-
-export default CustomerVerifier;

--- a/estela-web/src/defaultComponents/DropdownComponent/index.tsx
+++ b/estela-web/src/defaultComponents/DropdownComponent/index.tsx
@@ -1,5 +1,5 @@
 import type { MenuProps } from "antd";
 
-const userDropdownSidenavItems: MenuProps["items"] = [];
+const userDropdownSideNavItems: MenuProps["items"] = [];
 
-export default userDropdownSidenavItems;
+export default userDropdownSideNavItems;

--- a/estela-web/src/defaultComponents/ExternalVerifier/index.tsx
+++ b/estela-web/src/defaultComponents/ExternalVerifier/index.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const ExternalVerifier: React.FC = () => {
+    return <></>;
+};
+
+export default ExternalVerifier;

--- a/estela-web/src/pages/ActivatedAccountPage/index.tsx
+++ b/estela-web/src/pages/ActivatedAccountPage/index.tsx
@@ -1,10 +1,9 @@
 import React, { Component } from "react";
-import { Button, Space, Typography, Layout, Row } from "antd";
+import { Button, Typography, Layout, Row } from "antd";
 
 import history from "../../history";
 import { AuthService } from "../../services";
-import Bitmaker from "../../assets/logo/bitmaker.svg";
-import Estela from "../../assets/icons/estela.svg";
+import { EstelaBanner } from "../../components";
 
 const { Content } = Layout;
 const { Text } = Typography;
@@ -19,26 +18,13 @@ export class ActivatedAccountPage extends Component<unknown> {
     render(): JSX.Element {
         return (
             <Content className="h-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4">
-                <Content className="flex h-fit lg:ml-36 sm:h-fit md:h-full lg:h-full m-auto justify-center items-center p-14 sm:p-auto md:p-auto">
-                    <Content>
-                        <Estela className="w-48 h-24" />
-                        <p className="text-5xl font-bold mt-4">
-                            Stable, reliable and <span className="text-estela">open source</span>.
-                        </p>
-                        <p className="text-3xl font-normal py-6 sm:p-auto">
-                            Scrape <span className="text-estela">when you want it</span>.
-                        </p>
-                        <Space>
-                            <Text className="text-sm font-normal">Powered by&nbsp;</Text>
-                            <Bitmaker className="w-40 h-40" />
-                        </Space>
-                    </Content>
-                </Content>
+                <EstelaBanner />
                 <Content className="flex h-fit lg:mr-36 sm:h-fit md:h-full lg:h-full justify-center items-center p-6 sm:p-auto">
                     <Row justify="center" className="w-96">
                         <Text className="text-3xl font-bold">Account activated!</Text>
                         <Text className="text-center text-lg my-7 text-estela-black-medium">
-                            You have successfully activated your account. You can now login.
+                            You have successfully activated your account! <br />
+                            You can now log in
                         </Text>
                         <Button
                             block
@@ -47,7 +33,7 @@ export class ActivatedAccountPage extends Component<unknown> {
                                 history.push("/login");
                             }}
                         >
-                            Login
+                            Go to login
                         </Button>
                     </Row>
                 </Content>

--- a/estela-web/src/pages/ActivatedAccountPage/index.tsx
+++ b/estela-web/src/pages/ActivatedAccountPage/index.tsx
@@ -1,0 +1,57 @@
+import React, { Component } from "react";
+import { Button, Space, Typography, Layout, Row } from "antd";
+
+import history from "../../history";
+import { AuthService } from "../../services";
+import Bitmaker from "../../assets/logo/bitmaker.svg";
+import Estela from "../../assets/icons/estela.svg";
+
+const { Content } = Layout;
+const { Text } = Typography;
+
+export class ActivatedAccountPage extends Component<unknown> {
+    componentDidMount(): void {
+        if (AuthService.getAuthToken()) {
+            history.push("/projects");
+        }
+    }
+
+    render(): JSX.Element {
+        return (
+            <Content className="h-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4">
+                <Content className="flex h-fit lg:ml-36 sm:h-fit md:h-full lg:h-full m-auto justify-center items-center p-14 sm:p-auto md:p-auto">
+                    <Content>
+                        <Estela className="w-48 h-24" />
+                        <p className="text-5xl font-bold mt-4">
+                            Stable, reliable and <span className="text-estela">open source</span>.
+                        </p>
+                        <p className="text-3xl font-normal py-6 sm:p-auto">
+                            Scrape <span className="text-estela">when you want it</span>.
+                        </p>
+                        <Space>
+                            <Text className="text-sm font-normal">Powered by&nbsp;</Text>
+                            <Bitmaker className="w-40 h-40" />
+                        </Space>
+                    </Content>
+                </Content>
+                <Content className="flex h-fit lg:mr-36 sm:h-fit md:h-full lg:h-full justify-center items-center p-6 sm:p-auto">
+                    <Row justify="center" className="w-96">
+                        <Text className="text-3xl font-bold">Account activated!</Text>
+                        <Text className="text-center text-lg my-7 text-estela-black-medium">
+                            You have successfully activated your account. You can now login.
+                        </Text>
+                        <Button
+                            block
+                            className="border-estela bg-estela hover:border-estela hover:text-estela text-white rounded-md text-sm h-10"
+                            onClick={() => {
+                                history.push("/login");
+                            }}
+                        >
+                            Login
+                        </Button>
+                    </Row>
+                </Content>
+            </Content>
+        );
+    }
+}

--- a/estela-web/src/pages/CronJobDetailPage/index.tsx
+++ b/estela-web/src/pages/CronJobDetailPage/index.tsx
@@ -225,17 +225,7 @@ export class CronJobDetailPage extends Component<RouteComponentProps<RouteParams
             title: "SCHEDULED JOB",
             key: "cronjob",
             dataIndex: "cronjob",
-            render: (cronjob: number): ReactElement =>
-                cronjob ? (
-                    <Link
-                        to={`/projects/${this.projectId}/spiders/${this.spiderId}/cronjobs/${cronjob}`}
-                        className="text-estela-blue-medium"
-                    >
-                        Sche-Job-{cronjob}
-                    </Link>
-                ) : (
-                    <div></div>
-                ),
+            render: (cronjob: number): ReactElement => (cronjob ? <span>Sche-Job-{cronjob}</span> : <div></div>),
         },
         {
             title: "SPIDER",
@@ -303,7 +293,6 @@ export class CronJobDetailPage extends Component<RouteComponentProps<RouteParams
         };
         this.apiService.apiProjectsSpidersCronjobsRead(requestParams).then(
             async (response: SpiderCronJob) => {
-                console.log(response);
                 const args = response.cargs || [];
                 const envVars = response.cenvVars || [];
                 const tags = response.ctags || [];
@@ -442,7 +431,7 @@ export class CronJobDetailPage extends Component<RouteComponentProps<RouteParams
         const data = await this.getJobs(page);
         const jobs: SpiderJobData[] = data.data;
 
-        const waitingJobs = jobs.filter((job: SpiderJobData) => job.status === "IN_waiting");
+        const waitingJobs = jobs.filter((job: SpiderJobData) => job.status === "WAITING");
         const queueJobs = jobs.filter((job: SpiderJobData) => job.status === "IN_QUEUE");
         const runningJobs = jobs.filter((job: SpiderJobData) => job.status === "RUNNING");
         const completedJobs = jobs.filter((job: SpiderJobData) => job.status === "COMPLETED");

--- a/estela-web/src/pages/DeployListPage/index.tsx
+++ b/estela-web/src/pages/DeployListPage/index.tsx
@@ -170,7 +170,7 @@ export class DeployListPage extends Component<RouteComponentProps<RouteParams>, 
                                 <Col span={16}>
                                     <Text className="text-estela font-bold text-4xl">ONE STEP MISSING!</Text>
                                     <Paragraph className="text-xl my-6">
-                                        Install
+                                        Install the
                                         <a
                                             target="_blank"
                                             href="https://estela.bitmaker.la/docs/estela-cli/install.html"
@@ -178,12 +178,17 @@ export class DeployListPage extends Component<RouteComponentProps<RouteParams>, 
                                         >
                                             <Text className="text-estela underline mx-1">estela CLI</Text>
                                         </a>
-                                        to be able to access all Estela tools and
-                                        <Text className="font-bold"> deploy </Text> your spiders.
+                                        to <Text strong>deploy</Text> your spiders, unlock{" "}
+                                        <Text strong>advanced developer features</Text>, and access all{" "}
+                                        <Text strong>estela tools</Text>.
                                     </Paragraph>
                                     <Paragraph className="font-bold text-lg">
                                         Check all our documentation&nbsp;
-                                        <a target="_blank" href="https://estela.bitmaker.la/docs/" rel="noreferrer">
+                                        <a
+                                            target="_blank"
+                                            href="https://estela.bitmaker.la/docs/estela-cli/install.html"
+                                            rel="noreferrer"
+                                        >
                                             <Text className="text-estela underline">here!</Text>
                                         </a>
                                     </Paragraph>
@@ -197,7 +202,7 @@ export class DeployListPage extends Component<RouteComponentProps<RouteParams>, 
                                     className="w-96 h-14 px-10 bg-white border-estela text-estela rounded-lg"
                                     onClick={this.handleCloseModal}
                                 >
-                                    I have it installed
+                                    I already have it
                                 </Button>
                                 <Button
                                     target="_blank"
@@ -205,7 +210,7 @@ export class DeployListPage extends Component<RouteComponentProps<RouteParams>, 
                                     className="w-96 h-14 px-10 bg-estela-blue-full border-estela text-white rounded-lg flex flex-col justify-center"
                                     onClick={this.handleCloseModal}
                                 >
-                                    Install estela CLI
+                                    Install the estela CLI
                                 </Button>
                             </Row>
                         </Modal>
@@ -242,7 +247,8 @@ export class DeployListPage extends Component<RouteComponentProps<RouteParams>, 
                                                         </Text>
                                                     </a>
                                                     to <Text strong>streamline spider deployment</Text>, unlock{" "}
-                                                    <Text strong>advanced developer features</Text>, and more.
+                                                    <Text strong>advanced developer features</Text>, and access all{" "}
+                                                    <Text strong>estela tools</Text>.
                                                 </p>
                                             </Col>
                                         </Col>

--- a/estela-web/src/pages/ForgotPasswordPage/index.tsx
+++ b/estela-web/src/pages/ForgotPasswordPage/index.tsx
@@ -1,13 +1,14 @@
 import React, { Component } from "react";
-import { Button, Form, Input, Layout, Space, Typography, Row } from "antd";
+import { Link } from "react-router-dom";
+import { Button, Form, Input, Layout, Typography, Row } from "antd";
 import type { FormInstance } from "antd/es/form";
+
 import { ApiService } from "../../services";
 import { ApiAccountResetPasswordRequestRequest } from "../../services/api";
-import Bitmaker from "../../assets/logo/bitmaker.svg";
-import Estela from "../../assets/icons/estela.svg";
 import { Spin } from "../../shared";
-import { Link } from "react-router-dom";
 import { handleInvalidDataError } from "../../utils";
+import { EstelaBanner } from "../../components";
+
 const { Text } = Typography;
 const { Content } = Layout;
 
@@ -54,21 +55,7 @@ export class ForgotPasswordPage extends Component<unknown, ForgotPasswordPageSta
         const { loaded, requestSended, email, sendingRequest } = this.state;
         return loaded ? (
             <Content className="h-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4">
-                <Content className="flex h-fit lg:ml-36 sm:h-fit md:h-full lg:h-full m-auto justify-center items-center p-14 sm:p-auto md:p-auto">
-                    <Content>
-                        <Estela className="w-48 h-24" />
-                        <p className="text-5xl font-bold mt-4">
-                            Stable, reliable and <span className="text-estela">open source</span>.
-                        </p>
-                        <p className="text-3xl font-normal py-6 sm:p-auto">
-                            Scrape <span className="text-estela">when you want it</span>.
-                        </p>
-                        <Space>
-                            <Text className="text-sm font-normal">Powered by&nbsp;</Text>
-                            <Bitmaker className="w-40 h-40" />
-                        </Space>
-                    </Content>
-                </Content>
+                <EstelaBanner />
                 <Content className="flex h-fit lg:mr-36 sm:h-fit md:h-full lg:h-full justify-center items-center p-6 sm:p-auto">
                     {requestSended ? (
                         <Row justify="center">

--- a/estela-web/src/pages/JobDetailPage/index.tsx
+++ b/estela-web/src/pages/JobDetailPage/index.tsx
@@ -286,7 +286,6 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
             sid: this.spiderId,
             jid: this.jobId,
         };
-        console.log(this);
         this.apiService.apiProjectsSpidersJobsRead(requestParams).then(
             async (response: SpiderJob) => {
                 const args = response.args || [];
@@ -649,6 +648,7 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
 
     overview = (): React.ReactNode => {
         const {
+            cronjob,
             tags,
             lifespan,
             loadedItems,
@@ -755,6 +755,23 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
                                 <Text className="font-bold">Creation date</Text>
                             </Col>
                             <Col className="col-span-2 px-2">{date}</Col>
+                        </Row>
+                        <Row className="grid grid-cols-3 py-1 px-2">
+                            <Col className="col-span-1">
+                                <Text className="font-bold">Scheduled job</Text>
+                            </Col>
+                            <Col className="col-span-2 px-2">
+                                {cronjob ? (
+                                    <Link
+                                        to={`/projects/${this.projectId}/spiders/${this.spiderId}/cronjobs/${cronjob}`}
+                                        className="text-estela-blue-medium"
+                                    >
+                                        Sche-Job-{cronjob}
+                                    </Link>
+                                ) : (
+                                    <Text className="text-estela-black-medium text-xs">Not associated</Text>
+                                )}
+                            </Col>
                         </Row>
                         <Row className="grid grid-cols-3 bg-estela-blue-low py-1 px-2 rounded-lg">
                             <Col>

--- a/estela-web/src/pages/JobDetailPage/index.tsx
+++ b/estela-web/src/pages/JobDetailPage/index.tsx
@@ -286,6 +286,7 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
             sid: this.spiderId,
             jid: this.jobId,
         };
+        console.log(this);
         this.apiService.apiProjectsSpidersJobsRead(requestParams).then(
             async (response: SpiderJob) => {
                 const args = response.args || [];
@@ -723,16 +724,16 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
                         bordered={false}
                     >
                         <Text className="py-2 text-estela-black-medium font-medium text-base">DETAILS</Text>
-                        <Row className="grid grid-cols-3 py-1 px-2 mt-4">
+                        <Row className="grid grid-cols-3 py-1 px-2">
                             <Col>
-                                <Text className="font-bold">Spider ID</Text>
+                                <Text className="font-bold">Spider</Text>
                             </Col>
                             <Col>
                                 <Link
                                     to={`/projects/${this.projectId}/spiders/${this.spiderId}`}
                                     className="text-estela-blue-medium px-2"
                                 >
-                                    {this.spiderId}
+                                    {spiderName}
                                 </Link>
                             </Col>
                         </Row>
@@ -827,23 +828,24 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
                                 </Space>
                             </Col>
                         </Row>
-                        <Row className="grid grid-cols-3 py-1 px-2">
-                            <Col>
-                                <Text className="font-bold">Spider</Text>
-                            </Col>
-                            <Col>
-                                <Link
-                                    to={`/projects/${this.projectId}/spiders/${this.spiderId}`}
-                                    className="text-estela-blue-medium px-2"
-                                >
-                                    {spiderName}
-                                </Link>
-                            </Col>
-                        </Row>
                         <Row className="grid grid-cols-3 bg-estela-blue-low py-1 px-2 rounded-lg">
                             <Col>
                                 <Text className="font-bold">Job Status</Text>
                             </Col>
+                            {status == "IN_QUEUE" && (
+                                <Col className="col-span-2 px-2">
+                                    <Tag className="bg-estela-yellow-low text-estela-blue-full border-estela-blue-full rounded-md">
+                                        {status}
+                                    </Tag>
+                                </Col>
+                            )}
+                            {status == "WAITING" && (
+                                <Col className="col-span-2 px-2">
+                                    <Tag className="bg-estela-yellow-low text-estela-blue-full border-estela-blue-full rounded-md">
+                                        {status}
+                                    </Tag>
+                                </Col>
+                            )}
                             {status == "COMPLETED" && (
                                 <Col className="col-span-2 px-2">
                                     <Tag className="bg-estela-blue-low text-estela-blue-full border-estela-blue-full rounded-md">

--- a/estela-web/src/pages/LoginPage/index.tsx
+++ b/estela-web/src/pages/LoginPage/index.tsx
@@ -1,16 +1,14 @@
 import React, { Component } from "react";
-import { Button, Form, Input, Layout, Space, Typography, Row } from "antd";
+import { Button, Form, Input, Layout, Typography, Row } from "antd";
 import { Link } from "react-router-dom";
 
 import "./styles.scss";
 import history from "../../history";
 import { ApiService, AuthService } from "../../services";
 import { ApiAuthLoginRequest, Token } from "../../services/api";
-import Bitmaker from "../../assets/logo/bitmaker.svg";
-import Estela from "../../assets/icons/estela.svg";
 import { handleInvalidDataError } from "../../utils";
 import { UserContext, UserContextProps } from "../../context";
-import { FormInstance } from "antd/es/form";
+import { EstelaBanner } from "../../components";
 
 const { Content } = Layout;
 const { Text } = Typography;
@@ -25,13 +23,6 @@ export class LoginPage extends Component<unknown, LoginState> {
     };
     apiService = ApiService();
     static contextType = UserContext;
-
-    loginFormRef = React.createRef<
-        FormInstance<{
-            username: string;
-            password: string;
-        }>
-    >();
 
     componentDidMount(): void {
         if (AuthService.getAuthToken()) {
@@ -65,7 +56,6 @@ export class LoginPage extends Component<unknown, LoginState> {
             },
             (error: unknown) => {
                 handleInvalidDataError(error);
-                this.loginFormRef.current?.resetFields();
                 this.setState({ loading: false });
             },
         );
@@ -75,25 +65,11 @@ export class LoginPage extends Component<unknown, LoginState> {
         const { loading } = this.state;
         return (
             <Content className="h-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4">
-                <Content className="flex h-fit lg:ml-36 sm:h-fit md:h-full lg:h-full m-auto justify-center items-center p-14 sm:p-auto md:p-auto">
-                    <Content>
-                        <Estela className="w-48 h-24" />
-                        <p className="text-5xl font-bold mt-4">
-                            Stable, reliable and <span className="text-estela">open source</span>.
-                        </p>
-                        <p className="text-3xl font-normal py-6 sm:p-auto">
-                            Scrape <span className="text-estela">when you want it</span>.
-                        </p>
-                        <Space>
-                            <Text className="text-sm font-normal">Powered by&nbsp;</Text>
-                            <Bitmaker className="w-40 h-40" />
-                        </Space>
-                    </Content>
-                </Content>
+                <EstelaBanner />
                 <Content className="flex h-fit lg:mr-36 sm:h-fit md:h-full lg:h-full justify-center items-center p-6 sm:p-auto">
-                    <Form onFinish={this.handleSubmit} layout="vertical" className="p-2 w-96" ref={this.loginFormRef}>
+                    <Form onFinish={this.handleSubmit} layout="vertical" className="p-2 w-96">
                         <Row justify="center" className="w-96 my-7">
-                            <Text className="text-3xl font-bold">Log in</Text>
+                            <Text className="text-3xl font-bold">Login</Text>
                         </Row>
                         <Content>
                             <Form.Item
@@ -127,7 +103,7 @@ export class LoginPage extends Component<unknown, LoginState> {
                             htmlType="submit"
                             className="border-estela bg-estela hover:border-estela hover:text-estela text-white rounded-md text-sm h-10"
                         >
-                            Login
+                            Log in
                         </Button>
                         <Content className="text-center text-base m-5">
                             <p>If you don&apos;t have an account. You can</p>

--- a/estela-web/src/pages/LoginPage/index.tsx
+++ b/estela-web/src/pages/LoginPage/index.tsx
@@ -10,6 +10,7 @@ import Bitmaker from "../../assets/logo/bitmaker.svg";
 import Estela from "../../assets/icons/estela.svg";
 import { handleInvalidDataError } from "../../utils";
 import { UserContext, UserContextProps } from "../../context";
+import { FormInstance } from "antd/es/form";
 
 const { Content } = Layout;
 const { Text } = Typography;
@@ -24,6 +25,13 @@ export class LoginPage extends Component<unknown, LoginState> {
     };
     apiService = ApiService();
     static contextType = UserContext;
+
+    loginFormRef = React.createRef<
+        FormInstance<{
+            username: string;
+            password: string;
+        }>
+    >();
 
     componentDidMount(): void {
         if (AuthService.getAuthToken()) {
@@ -57,6 +65,8 @@ export class LoginPage extends Component<unknown, LoginState> {
             },
             (error: unknown) => {
                 handleInvalidDataError(error);
+                this.loginFormRef.current?.resetFields();
+                this.setState({ loading: false });
             },
         );
     };
@@ -81,7 +91,7 @@ export class LoginPage extends Component<unknown, LoginState> {
                     </Content>
                 </Content>
                 <Content className="flex h-fit lg:mr-36 sm:h-fit md:h-full lg:h-full justify-center items-center p-6 sm:p-auto">
-                    <Form onFinish={this.handleSubmit} layout="vertical" className="p-2 w-96">
+                    <Form onFinish={this.handleSubmit} layout="vertical" className="p-2 w-96" ref={this.loginFormRef}>
                         <Row justify="center" className="w-96 my-7">
                             <Text className="text-3xl font-bold">Log in</Text>
                         </Row>

--- a/estela-web/src/pages/ProjectCronJobListPage/index.tsx
+++ b/estela-web/src/pages/ProjectCronJobListPage/index.tsx
@@ -28,8 +28,13 @@ import { convertDateToString } from "../../utils";
 
 const { Content } = Layout;
 
-interface Ids {
+interface SpiderData {
     sid: number;
+    name: string;
+}
+
+interface BaseInfo {
+    spider: SpiderData;
     cid: number | undefined;
 }
 
@@ -43,7 +48,7 @@ interface Args {
 }
 
 interface SpiderCronJobData {
-    id: Ids;
+    id: BaseInfo;
     key: number | undefined;
     date: string;
     status: string | undefined;
@@ -138,18 +143,25 @@ export class ProjectCronJobListPage extends Component<RouteComponentProps<RouteP
         },
         {
             title: "SCHEDULED JOB",
-            dataIndex: "id",
-            key: "id",
-            render: (id: Ids): ReactElement => (
-                <Link to={`/projects/${this.projectId}/spiders/${id.sid}/cronjobs/${id.cid}`}>{id.cid}</Link>
+            dataIndex: "info",
+            key: "info",
+            render: (info: BaseInfo): ReactElement => (
+                <Link
+                    to={`/projects/${this.projectId}/spiders/${info.spider.sid}/cronjobs/${info.cid}`}
+                    className="text-estela-blue-medium"
+                >
+                    Sche-Job-{info.cid}
+                </Link>
             ),
         },
         {
             title: "SPIDER",
-            dataIndex: "id",
-            key: "id",
-            render: (id: Ids): ReactElement => (
-                <Link to={`/projects/${this.projectId}/spiders/${id.sid}`}>{id.sid}</Link>
+            dataIndex: "info",
+            key: "info",
+            render: (info: BaseInfo): ReactElement => (
+                <Link to={`/projects/${this.projectId}/spiders/${info.spider.sid}`} className="text-estela-blue-medium">
+                    {info.spider.name}
+                </Link>
             ),
         },
         {
@@ -219,7 +231,7 @@ export class ProjectCronJobListPage extends Component<RouteComponentProps<RouteP
         await this.apiService.apiProjectsCronjobs(requestParams).then((response: ProjectCronJob) => {
             const data = response.results.map((cronjob: SpiderCronJob, iterator: number) => ({
                 key: iterator,
-                id: { sid: cronjob.spider, cid: cronjob.cjid },
+                info: { spider: cronjob.spider, cid: cronjob.cjid },
                 date: convertDateToString(cronjob.created),
                 status: cronjob.status,
                 schedule: cronjob.schedule,
@@ -239,8 +251,8 @@ export class ProjectCronJobListPage extends Component<RouteComponentProps<RouteP
                 ? SpiderCronJobUpdateStatusEnum.Active
                 : SpiderCronJobUpdateStatusEnum.Disabled;
         const request: ApiProjectsSpidersCronjobsUpdateRequest = {
-            cjid: Number(cronjob.id.cid),
-            sid: String(cronjob.id.sid),
+            cjid: Number(cronjob.info.cid),
+            sid: String(cronjob.info.spider.sid),
             pid: this.projectId,
             data: {
                 status: _status,
@@ -281,14 +293,14 @@ export class ProjectCronJobListPage extends Component<RouteComponentProps<RouteP
     };
 
     editCronjob = (cronjob: SpiderCronJobData): void => {
-        history.push(`/projects/${this.projectId}/spiders/${cronjob.id.sid}/cronjobs/${cronjob.id.cid}`);
+        history.push(`/projects/${this.projectId}/spiders/${cronjob.info.spider.sid}/cronjobs/${cronjob.info.cid}`);
     };
 
     runOnce = (cronjob: SpiderCronJobData): void => {
         const requestParams: ApiProjectsSpidersCronjobsRunOnceRequest = {
             pid: this.projectId,
-            sid: String(cronjob.id.sid),
-            cjid: Number(cronjob.id.cid),
+            sid: String(cronjob.info.spider.sid),
+            cjid: Number(cronjob.info.cid),
         };
         this.apiService.apiProjectsSpidersCronjobsRunOnce(requestParams).then(
             async (response: SpiderCronJob) => {
@@ -303,8 +315,8 @@ export class ProjectCronJobListPage extends Component<RouteComponentProps<RouteP
     deleteCronjob = (cronjob: SpiderCronJobData): void => {
         const requestParams: ApiProjectsSpidersCronjobsDeleteRequest = {
             pid: this.projectId,
-            sid: String(cronjob.id.sid),
-            cjid: Number(cronjob.id.cid),
+            sid: String(cronjob.info.spider.sid),
+            cjid: Number(cronjob.info.cid),
         };
         this.apiService.apiProjectsSpidersCronjobsDelete(requestParams).then(
             () => {

--- a/estela-web/src/pages/ProjectListPage/index.tsx
+++ b/estela-web/src/pages/ProjectListPage/index.tsx
@@ -141,7 +141,7 @@ export class ProjectListPage extends Component<unknown, ProjectsPageState> {
                 if (response.users && response.users.length > 0) {
                     updateRole && updateRole(response.users[0].permission ?? "");
                 }
-                history.push(`/projects/${response.pid}/dashboard`);
+                history.push(`/projects/${response.pid}/deploys`);
             },
             (error: unknown) => {
                 error;

--- a/estela-web/src/pages/ProjectSettingsPage/index.tsx
+++ b/estela-web/src/pages/ProjectSettingsPage/index.tsx
@@ -226,7 +226,7 @@ export class ProjectSettingsPage extends Component<RouteComponentProps<RoutePara
                 {loaded ? (
                     <div className="lg:m-10 md:mx-6 m-6">
                         <Row className="font-medium my-6">
-                            <p className="text-xl text-silver">PROJECT SETTING</p>
+                            <p className="text-xl text-silver">PROJECT SETTINGS</p>
                         </Row>
                         <Row className="bg-white rounded-lg">
                             <div className="lg:m-8 md:mx-6 m-4">

--- a/estela-web/src/pages/RegisterPage/index.tsx
+++ b/estela-web/src/pages/RegisterPage/index.tsx
@@ -15,7 +15,15 @@ import { handleInvalidDataError } from "../../utils";
 const { Content } = Layout;
 const { Text } = Typography;
 
-export class RegisterPage extends Component<unknown> {
+interface RegisterPageState {
+    successRegister: boolean;
+}
+
+export class RegisterPage extends Component<unknown, RegisterPageState> {
+    state: RegisterPageState = {
+        successRegister: false,
+    };
+
     apiService = ApiService();
 
     componentDidMount(): void {
@@ -69,7 +77,7 @@ export class RegisterPage extends Component<unknown> {
                     AuthService.setUserUsername(response.user.username);
                 }
                 emailConfirmationNotification();
-                history.push("/login");
+                this.setState({ successRegister: true });
             },
             (error: unknown) => {
                 handleInvalidDataError(error);
@@ -96,55 +104,73 @@ export class RegisterPage extends Component<unknown> {
                     </Content>
                 </Content>
                 <Content className="flex h-fit lg:mr-36 sm:h-fit md:h-full lg:h-full justify-center items-center p-6 sm:p-auto">
-                    <Form onFinish={this.handleSubmit} layout="vertical" className="p-2 w-96">
-                        <Row justify="center" className="w-96 my-7">
-                            <Text className="text-3xl font-bold">Sign up</Text>
+                    {!this.state.successRegister ? (
+                        <Form onFinish={this.handleSubmit} layout="vertical" className="p-2 w-96">
+                            <Row justify="center" className="w-96 my-7">
+                                <Text className="text-3xl font-bold">Sign up</Text>
+                            </Row>
+                            <Content className="">
+                                <Form.Item
+                                    label="Email"
+                                    name="email"
+                                    required
+                                    rules={[{ required: true, message: "Please input your email", type: "email" }]}
+                                >
+                                    <Input autoComplete="email" className="border-estela rounded-md py-2" />
+                                </Form.Item>
+                                <Form.Item
+                                    label="Username"
+                                    name="username"
+                                    required
+                                    rules={[{ required: true, message: "Please input your username" }]}
+                                >
+                                    <Input autoComplete="username" className="border-estela rounded-md py-2" />
+                                </Form.Item>
+                                <Form.Item
+                                    label="Password"
+                                    name="password"
+                                    required
+                                    rules={[{ required: true, message: "Please input your password" }]}
+                                >
+                                    <Input.Password
+                                        autoComplete="current-password"
+                                        className="border-estela rounded-md py-2"
+                                    />
+                                </Form.Item>
+                            </Content>
+                            <Button
+                                block
+                                htmlType="submit"
+                                className="border-estela bg-estela hover:border-estela hover:text-estela text-white rounded-md text-sm h-10"
+                            >
+                                Register
+                            </Button>
+                            <Content className="text-center text-base m-5">
+                                <p>If you already have an account. You can</p>
+                                <p>
+                                    <Link className="text-estela text-base font-bold underline" to="/login">
+                                        login here
+                                    </Link>
+                                </p>
+                            </Content>
+                        </Form>
+                    ) : (
+                        <Row justify="center" className="w-96">
+                            <Text className="text-3xl font-bold">Thanks for registering!</Text>
+                            <Text className="text-center text-lg my-7 text-estela-black-medium">
+                                We are thrilled to have you join us!
+                            </Text>
+                            <Button
+                                block
+                                className="border-estela bg-estela hover:border-estela hover:text-estela text-white rounded-md text-sm h-10"
+                                onClick={() => {
+                                    history.push("/login");
+                                }}
+                            >
+                                Login
+                            </Button>
                         </Row>
-                        <Content className="">
-                            <Form.Item
-                                label="Email"
-                                name="email"
-                                required
-                                rules={[{ required: true, message: "Please input your email", type: "email" }]}
-                            >
-                                <Input autoComplete="email" className="border-estela rounded-md py-2" />
-                            </Form.Item>
-                            <Form.Item
-                                label="Username"
-                                name="username"
-                                required
-                                rules={[{ required: true, message: "Please input your username" }]}
-                            >
-                                <Input autoComplete="username" className="border-estela rounded-md py-2" />
-                            </Form.Item>
-                            <Form.Item
-                                label="Password"
-                                name="password"
-                                required
-                                rules={[{ required: true, message: "Please input your password" }]}
-                            >
-                                <Input.Password
-                                    autoComplete="current-password"
-                                    className="border-estela rounded-md py-2"
-                                />
-                            </Form.Item>
-                        </Content>
-                        <Button
-                            block
-                            htmlType="submit"
-                            className="border-estela bg-estela hover:border-estela hover:text-estela text-white rounded-md text-sm h-10"
-                        >
-                            Register
-                        </Button>
-                        <Content className="text-center text-base m-5">
-                            <p>If you already have an account. You can</p>
-                            <p>
-                                <Link className="text-estela text-base font-bold underline" to="/login">
-                                    login here
-                                </Link>
-                            </p>
-                        </Content>
-                    </Form>
+                    )}
                 </Content>
             </Content>
         );

--- a/estela-web/src/pages/RegisterPage/index.tsx
+++ b/estela-web/src/pages/RegisterPage/index.tsx
@@ -1,14 +1,13 @@
 import React, { Component } from "react";
-import { Button, Form, Space, Typography, Input, Layout, Row } from "antd";
+import { Button, Form, Typography, Input, Layout, Row } from "antd";
 import { Link } from "react-router-dom";
 
 import "./styles.scss";
 import history from "../../history";
 import { ApiService, AuthService } from "../../services";
 import { ApiAuthRegisterRequest, Token } from "../../services/api";
-import Bitmaker from "../../assets/logo/bitmaker.svg";
-import Estela from "../../assets/icons/estela.svg";
 import { insecurePasswordNotification, emailConfirmationNotification } from "../../shared";
+import { EstelaBanner } from "../../components";
 
 import { handleInvalidDataError } from "../../utils";
 
@@ -16,11 +15,13 @@ const { Content } = Layout;
 const { Text } = Typography;
 
 interface RegisterPageState {
+    loading: boolean;
     successRegister: boolean;
 }
 
 export class RegisterPage extends Component<unknown, RegisterPageState> {
     state: RegisterPageState = {
+        loading: false,
         successRegister: false,
     };
 
@@ -66,6 +67,7 @@ export class RegisterPage extends Component<unknown, RegisterPageState> {
     }
 
     handleSubmit = (data: { email: string; username: string; password: string }): void => {
+        this.setState({ loading: true });
         if (!this.validatePassword(data.password)) {
             return;
         }
@@ -78,31 +80,20 @@ export class RegisterPage extends Component<unknown, RegisterPageState> {
                 }
                 emailConfirmationNotification();
                 this.setState({ successRegister: true });
+                this.setState({ loading: false });
             },
             (error: unknown) => {
                 handleInvalidDataError(error);
+                this.setState({ loading: false });
             },
         );
     };
 
     render(): JSX.Element {
+        const { loading } = this.state;
         return (
             <Content className="h-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4">
-                <Content className="flex h-fit lg:ml-36 sm:h-fit md:h-full lg:h-full m-auto justify-center items-center p-14 sm:p-auto md:p-auto">
-                    <Content>
-                        <Estela className="w-48 h-24" />
-                        <p className="text-5xl font-bold mt-4">
-                            Stable, reliable and <span className="text-estela">open source</span>.
-                        </p>
-                        <p className="text-3xl font-normal py-6 sm:p-auto">
-                            Scrape <span className="text-estela">when you want it</span>.
-                        </p>
-                        <Space>
-                            <Text className="text-sm font-normal">Powered by&nbsp;</Text>
-                            <Bitmaker className="w-40 h-40" />
-                        </Space>
-                    </Content>
-                </Content>
+                <EstelaBanner />
                 <Content className="flex h-fit lg:mr-36 sm:h-fit md:h-full lg:h-full justify-center items-center p-6 sm:p-auto">
                     {!this.state.successRegister ? (
                         <Form onFinish={this.handleSubmit} layout="vertical" className="p-2 w-96">
@@ -139,6 +130,7 @@ export class RegisterPage extends Component<unknown, RegisterPageState> {
                                 </Form.Item>
                             </Content>
                             <Button
+                                loading={loading}
                                 block
                                 htmlType="submit"
                                 className="border-estela bg-estela hover:border-estela hover:text-estela text-white rounded-md text-sm h-10"
@@ -149,7 +141,7 @@ export class RegisterPage extends Component<unknown, RegisterPageState> {
                                 <p>If you already have an account. You can</p>
                                 <p>
                                     <Link className="text-estela text-base font-bold underline" to="/login">
-                                        login here
+                                        log in here
                                     </Link>
                                 </p>
                             </Content>
@@ -158,7 +150,8 @@ export class RegisterPage extends Component<unknown, RegisterPageState> {
                         <Row justify="center" className="w-96">
                             <Text className="text-3xl font-bold">Thanks for registering!</Text>
                             <Text className="text-center text-lg my-7 text-estela-black-medium">
-                                We are thrilled to have you join us!
+                                We are thrilled to have you join us! <br />
+                                Check the email we just sent you to activate your account
                             </Text>
                             <Button
                                 block
@@ -167,7 +160,7 @@ export class RegisterPage extends Component<unknown, RegisterPageState> {
                                     history.push("/login");
                                 }}
                             >
-                                Login
+                                Log in
                             </Button>
                         </Row>
                     )}

--- a/estela-web/src/pages/ResetPasswordPage/index.tsx
+++ b/estela-web/src/pages/ResetPasswordPage/index.tsx
@@ -1,13 +1,14 @@
 import React, { Component } from "react";
-import { Button, Form, Input, Layout, Space, Typography, Row } from "antd";
+import { Button, Form, Input, Layout, Typography, Row } from "antd";
 import type { FormInstance } from "antd/es/form";
+
 import { ApiService } from "../../services";
 import { ApiAccountResetPasswordConfirmRequest, ApiAccountResetPasswordValidateRequest } from "../../services/api";
 import history from "../../history";
-import Bitmaker from "../../assets/logo/bitmaker.svg";
-import Estela from "../../assets/icons/estela.svg";
 import { Spin } from "../../shared";
 import { handleInvalidDataError } from "../../utils";
+import { EstelaBanner } from "../../components";
+
 const { Text } = Typography;
 const { Content } = Layout;
 
@@ -104,21 +105,7 @@ export class ResetPasswordPage extends Component<ResetPasswordPageProps, ResetPa
         const { loaded, successfullyChanged, linkExpired, sendingRequest } = this.state;
         return loaded ? (
             <Content className="h-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4">
-                <Content className="flex h-fit lg:ml-36 sm:h-fit md:h-full lg:h-full m-auto justify-center items-center p-14 sm:p-auto md:p-auto">
-                    <Content>
-                        <Estela className="w-48 h-24" />
-                        <p className="text-5xl font-bold mt-4">
-                            Stable, reliable and <span className="text-estela">open source</span>.
-                        </p>
-                        <p className="text-3xl font-normal py-6 sm:p-auto">
-                            Scrape <span className="text-estela">when you want it</span>.
-                        </p>
-                        <Space>
-                            <Text className="text-sm font-normal">Powered by&nbsp;</Text>
-                            <Bitmaker className="w-40 h-40" />
-                        </Space>
-                    </Content>
-                </Content>
+                <EstelaBanner />
                 <Content className="flex h-fit lg:mr-36 sm:h-fit md:h-full lg:h-full justify-center items-center p-6 sm:p-auto">
                     {successfullyChanged ? (
                         <Row justify="center" className="w-96">

--- a/estela-web/src/pages/SpiderDetailPage/index.tsx
+++ b/estela-web/src/pages/SpiderDetailPage/index.tsx
@@ -150,11 +150,7 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
             title: "SPIDER",
             dataIndex: "spider",
             key: "spider",
-            render: (spider: SpiderData): ReactElement => (
-                <Link to={`/projects/${this.projectId}/spiders/${this.spiderId}`} className="text-estela-blue-medium">
-                    {spider.name}
-                </Link>
-            ),
+            render: (spider: SpiderData): ReactElement => <span>{spider.name}</span>,
         },
         {
             title: "SCHEDULED JOB",

--- a/estela-web/src/pages/SpiderDetailPage/index.tsx
+++ b/estela-web/src/pages/SpiderDetailPage/index.tsx
@@ -44,15 +44,21 @@ import { convertDateToString, handleInvalidDataError } from "../../utils";
 const { Content } = Layout;
 const { Text } = Typography;
 
-const queued = 0;
-const running = 1;
-const completed = 2;
-const withError = 3;
+const waiting = 0;
+const queued = 1;
+const running = 2;
+const completed = 3;
+const withError = 4;
+
+interface SpiderData {
+    sid: number;
+    name: string;
+}
 
 interface SpiderJobData {
     id: number | null | undefined;
     key: number | null | undefined;
-    spider: number | null | undefined;
+    spider: SpiderData;
     jobStatus: string | null | undefined;
     cronjob: number | null | undefined;
     args: SpiderJobArg[] | undefined;
@@ -68,6 +74,7 @@ interface SpiderDetailPageState {
     optionTab: string;
     tableStatus: boolean[];
     jobs: SpiderJobData[];
+    waitingJobs: SpiderJobData[];
     queueJobs: SpiderJobData[];
     runningJobs: SpiderJobData[];
     completedJobs: SpiderJobData[];
@@ -108,6 +115,7 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
         count: 0,
         current: 0,
         optionTab: "overview",
+        waitingJobs: [],
         queueJobs: [],
         runningJobs: [],
         completedJobs: [],
@@ -118,7 +126,7 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
         dataExpiryDays: 1,
         persistenceChanged: false,
         newDataStatus: undefined,
-        tableStatus: new Array<boolean>(4).fill(true),
+        tableStatus: new Array<boolean>(5).fill(true),
     };
     apiService = ApiService();
     projectId: string = this.props.match.params.projectId;
@@ -139,12 +147,12 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
             ),
         },
         {
-            title: "SPIDER ID",
+            title: "SPIDER",
             dataIndex: "spider",
             key: "spider",
-            render: (spiderID: number): ReactElement => (
+            render: (spider: SpiderData): ReactElement => (
                 <Link to={`/projects/${this.projectId}/spiders/${this.spiderId}`} className="text-estela-blue-medium">
-                    {spiderID}
+                    {spider.name}
                 </Link>
             ),
         },
@@ -209,22 +217,28 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
         this.apiService.apiProjectsSpidersRead(requestParams).then(
             async (response: Spider) => {
                 const data = await this.getSpiderJobs(1);
-                const completedJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "COMPLETED");
-                const runningJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "RUNNING");
+
+                const waitingJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "WAITING");
                 const queueJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "IN_QUEUE");
+                const runningJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "RUNNING");
+                const completedJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "COMPLETED");
                 const errorJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "ERROR");
+
                 const scheduledJobsCount = data.data
                     .filter((job: SpiderJobData) => job.cronjob !== null && job.cronjob !== undefined)
                     .map((job: SpiderJobData) => job.cronjob)
                     .filter((cronjob, index, self) => {
                         return self.indexOf(cronjob) === index;
                     }).length;
+
                 const tableStatus = [
+                    !(waitingJobs.length === 0),
                     !(queueJobs.length === 0),
                     !(runningJobs.length === 0),
                     !(completedJobs.length === 0),
                     !(errorJobs.length === 0),
                 ];
+
                 const jobs: SpiderJobData[] = data.data;
                 this.setState({
                     spider: response,
@@ -236,6 +250,7 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
                     current: data.current,
                     loaded: true,
                     tableStatus: [...tableStatus],
+                    waitingJobs: [...waitingJobs],
                     queueJobs: [...queueJobs],
                     runningJobs: [...runningJobs],
                     completedJobs: [...completedJobs],
@@ -327,23 +342,29 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
     onPageChange = async (page: number): Promise<void> => {
         this.setState({ loaded: false });
         const data = await this.getSpiderJobs(page);
-        const jobs: SpiderJobData[] = data.data;
-        const completedJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "COMPLETED");
-        const runningJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "RUNNING");
+
+        const waitingJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "WAITING");
         const queueJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "IN_QUEUE");
+        const runningJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "RUNNING");
+        const completedJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "COMPLETED");
         const errorJobs = data.data.filter((job: SpiderJobData) => job.jobStatus === "ERROR");
+
         const tableStatus = [
+            !(waitingJobs.length === 0),
             !(queueJobs.length === 0),
             !(runningJobs.length === 0),
             !(completedJobs.length === 0),
             !(errorJobs.length === 0),
         ];
+
+        const jobs: SpiderJobData[] = data.data;
         this.setState({
             jobs: [...jobs],
             count: data.count,
             current: data.current,
             loaded: true,
             tableStatus: [...tableStatus],
+            waitingJobs: [...waitingJobs],
             queueJobs: [...queueJobs],
             runningJobs: [...runningJobs],
             completedJobs: [...completedJobs],
@@ -374,6 +395,7 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
             jobs,
             count,
             current,
+            waitingJobs,
             queueJobs,
             runningJobs,
             completedJobs,
@@ -412,7 +434,12 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
                                     <p className="text-sm font-bold">Project ID</p>
                                 </div>
                                 <div className="col-span-2">
-                                    <p className="text-sm text-silver">{this.projectId}</p>
+                                    <Link
+                                        to={`/projects/${this.projectId}/dashboard`}
+                                        className="text-estela-blue-medium text-sm"
+                                    >
+                                        {this.projectId}
+                                    </Link>
                                 </div>
                             </div>
                             <div className="grid grid-cols-3 p-2 rounded-lg">
@@ -428,6 +455,63 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
                 </Row>
                 <Content className="grid gap-2 grid-cols-1 lg:grid-cols-5 items-start w-full">
                     <Col className="float-left col-span-4">
+                        {tableStatus[waiting] && (
+                            <Row className="my-2 rounded-lg bg-white">
+                                <Content className="flow-root lg:m-4 mx-4 my-2 w-full">
+                                    <Col className="float-left py-1">
+                                        <Text className="mr-2 text-estela-black-medium font-medium text-lg">
+                                            Waiting
+                                        </Text>
+                                        <Tag className="rounded-2xl bg-estela-white-medium text-estela-black-low border-estela-white-medium">
+                                            {waitingJobs.length}
+                                        </Tag>
+                                    </Col>
+                                    <Col className="flex float-right">
+                                        <Button
+                                            disabled
+                                            icon={<Filter className="h-6 w-6 mr-2" />}
+                                            size="large"
+                                            className="flex items-center mr-2 stroke-estela-blue-full border-estela-blue-low bg-estela-blue-low text-estela-blue-full hover:text-estela-blue-full text-sm hover:border-estela rounded-2xl"
+                                        >
+                                            Filter
+                                        </Button>
+                                        <Button
+                                            disabled
+                                            icon={<Setting className="h-6 w-6" />}
+                                            size="large"
+                                            className="flex items-center justify-center stroke-estela-black-medium border-none hover:stroke-estela bg-white"
+                                        ></Button>
+                                    </Col>
+                                </Content>
+                                <Content className="mx-4 my-1">
+                                    <Table
+                                        scroll={{}}
+                                        size="small"
+                                        rowSelection={{
+                                            type: "checkbox",
+                                        }}
+                                        columns={this.columns}
+                                        dataSource={waitingJobs}
+                                        pagination={false}
+                                    />
+                                </Content>
+                                <Row className="w-full h-6 bg-estela-white-low"></Row>
+                                <Space direction="horizontal" className="my-2 mx-4">
+                                    <Button
+                                        disabled
+                                        className="bg-estela-red-low border-estela-red-low text-estela-red-full hover:bg-estela-red-low hover:text-estela-red-full hover:border-estela-red-full rounded-2xl"
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button
+                                        disabled
+                                        className="bg-estela-blue-low border-estela-blue-low text-estela-blue-full hover:bg-estela-blue-low hover:text-estela-blue-full hover:border-estela-blue-full rounded-2xl"
+                                    >
+                                        Edit
+                                    </Button>
+                                </Space>
+                            </Row>
+                        )}
                         {tableStatus[queued] && (
                             <Row className="my-2 rounded-lg bg-white">
                                 <Content className="flow-root lg:m-4 mx-4 my-2 w-full">
@@ -651,6 +735,18 @@ export class SpiderDetailPage extends Component<RouteComponentProps<RouteParams>
                         <Content className="my-2 mx-3">
                             <Text className="text-estela-black-medium font-medium text-xs">STATUS</Text>
                             <Content className="my-2">
+                                <Checkbox
+                                    checked={waitingJobs.length === 0 ? tableStatus[waiting] : true}
+                                    onChange={() => this.onChangeStatus(waiting, waitingJobs.length)}
+                                >
+                                    <Space direction="horizontal">
+                                        <Text className="text-estela-black-medium font-medium text-sm">Waiting</Text>
+                                        <Tag className="rounded-2xl bg-estela-white-medium text-estela-black-low border-estela-white-medium">
+                                            {waitingJobs.length}
+                                        </Tag>
+                                    </Space>
+                                </Checkbox>
+                                <br />
                                 <Checkbox
                                     checked={queueJobs.length === 0 ? tableStatus[queued] : true}
                                     onChange={() => this.onChangeStatus(queued, queueJobs.length)}

--- a/estela-web/src/routes/index.tsx
+++ b/estela-web/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Switch, Route, Redirect } from "react-router-dom";
 
+import { ActivatedAccountPage } from "../pages/ActivatedAccountPage";
 import { LoginPage } from "../pages/LoginPage";
 import { RegisterPage } from "../pages/RegisterPage";
 import { NotificationsInboxPage } from "../pages/NotificationsInboxPage";
@@ -33,12 +34,13 @@ export const MainRoutes: React.FC = () => {
                 <Redirect to="/login" />
             </Route>
 
-            <Route path={["/login", "/register", "/forgotPassword", "/resetPassword"]} exact>
+            <Route path={["/login", "/register", "/forgotPassword", "/resetPassword", "/activatedAccount"]} exact>
                 <AuthLayout>
                     <Route path="/login" component={LoginPage} exact />
                     <Route path="/register" component={RegisterPage} exact />
                     <Route path="/forgotPassword" component={ForgotPasswordPage} exact />
                     <Route path="/resetPassword" component={ResetPasswordPage} exact />
+                    <Route path="/activatedAccount" component={ActivatedAccountPage} exact />
                 </AuthLayout>
             </Route>
 

--- a/estela-web/src/services/api/generated-api/models/SpiderCronJob.ts
+++ b/estela-web/src/services/api/generated-api/models/SpiderCronJob.ts
@@ -41,11 +41,11 @@ export interface SpiderCronJob {
      */
     readonly cjid?: number;
     /**
-     * Spider sid.
-     * @type {number}
+     * 
+     * @type {string}
      * @memberof SpiderCronJob
      */
-    spider: number;
+    readonly spider?: string;
     /**
      * Cron job creation date.
      * @type {Date}
@@ -135,7 +135,7 @@ export function SpiderCronJobFromJSONTyped(json: any, ignoreDiscriminator: boole
     return {
         
         'cjid': !exists(json, 'cjid') ? undefined : json['cjid'],
-        'spider': json['spider'],
+        'spider': !exists(json, 'spider') ? undefined : json['spider'],
         'created': !exists(json, 'created') ? undefined : (new Date(json['created'])),
         'name': !exists(json, 'name') ? undefined : json['name'],
         'cargs': !exists(json, 'cargs') ? undefined : ((json['cargs'] as Array<any>).map(SpiderJobArgFromJSON)),
@@ -158,7 +158,6 @@ export function SpiderCronJobToJSON(value?: SpiderCronJob | null): any {
     }
     return {
         
-        'spider': value.spider,
         'cargs': value.cargs === undefined ? undefined : ((value.cargs as Array<any>).map(SpiderJobArgToJSON)),
         'cenv_vars': value.cenvVars === undefined ? undefined : ((value.cenvVars as Array<any>).map(SpiderJobEnvVarToJSON)),
         'ctags': value.ctags === undefined ? undefined : ((value.ctags as Array<any>).map(SpiderJobTagToJSON)),

--- a/estela-web/src/services/api/generated-api/models/SpiderJob.ts
+++ b/estela-web/src/services/api/generated-api/models/SpiderJob.ts
@@ -41,11 +41,11 @@ export interface SpiderJob {
      */
     readonly jid?: number;
     /**
-     * Spider sid.
-     * @type {number}
+     * 
+     * @type {string}
      * @memberof SpiderJob
      */
-    spider: number;
+    readonly spider?: string;
     /**
      * Job creation date.
      * @type {Date}
@@ -147,7 +147,7 @@ export function SpiderJobFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     return {
         
         'jid': !exists(json, 'jid') ? undefined : json['jid'],
-        'spider': json['spider'],
+        'spider': !exists(json, 'spider') ? undefined : json['spider'],
         'created': !exists(json, 'created') ? undefined : (new Date(json['created'])),
         'name': !exists(json, 'name') ? undefined : json['name'],
         'lifespan': !exists(json, 'lifespan') ? undefined : json['lifespan'],
@@ -173,7 +173,6 @@ export function SpiderJobToJSON(value?: SpiderJob | null): any {
     }
     return {
         
-        'spider': value.spider,
         'lifespan': value.lifespan,
         'total_response_bytes': value.totalResponseBytes,
         'item_count': value.itemCount,

--- a/estela-web/src/services/api/generated-api/models/SpiderJobUpdate.ts
+++ b/estela-web/src/services/api/generated-api/models/SpiderJobUpdate.ts
@@ -56,17 +56,17 @@ export interface SpiderJobUpdate {
      */
     requestCount?: number;
     /**
-     * Data status.
+     * Job data status.
      * @type {string}
      * @memberof SpiderJobUpdate
      */
     dataStatus?: SpiderJobUpdateDataStatusEnum;
     /**
-     * Days before data is deleted.
+     * Job data expiry days.
      * @type {number}
      * @memberof SpiderJobUpdate
      */
-    dataExpiryDays?: number | null;
+    dataExpiryDays?: number;
 }
 
 /**

--- a/estela-web/src/shared/header/index.tsx
+++ b/estela-web/src/shared/header/index.tsx
@@ -14,7 +14,7 @@ import Dashboard from "../../assets/icons/dashboard.svg";
 import Settings from "../../assets/icons/setting.svg";
 import Logout from "../../assets/icons/logout.svg";
 import Circle from "../../assets/icons/ellipse.svg";
-import userDropdownSidenavItems from "ExternalComponents/DropdownComponent";
+import userDropdownSideNavItems from "ExternalComponents/DropdownComponent";
 
 const { Header, Content } = Layout;
 type MenuItem = Required<MenuProps>["items"][number];
@@ -36,7 +36,7 @@ export class CustomHeader extends Component<unknown, HeaderState> {
     timer: NodeJS.Timeout | undefined;
 
     async componentDidMount() {
-        userDropdownSidenavItems.forEach((element: MenuItem) => {
+        userDropdownSideNavItems.forEach((element: MenuItem) => {
             this.itemsUser?.push(element);
         });
         const key_logout = this.itemsUser?.length;

--- a/estela-web/src/shared/index.tsx
+++ b/estela-web/src/shared/index.tsx
@@ -1,7 +1,7 @@
 export { CustomHeader as Header } from "./header";
-export { ProjectSidenav } from "./projectSidenav";
-export { ProfileSettingsSideNav } from "./profileSettingsSidenav";
-export { NotificationsSidenav } from "./notificationsSidenav";
+export { ProjectSideNav } from "./projectSideNav";
+export { ProfileSettingsSideNav } from "./profileSettingsSideNav";
+export { NotificationsSideNav } from "./notificationsSideNav";
 export { CustomSpin as Spin } from "./spin";
 export { PaginationItem } from "./paginationItem";
 export * from "./notifications";

--- a/estela-web/src/shared/layouts/NotificationsLayout.tsx
+++ b/estela-web/src/shared/layouts/NotificationsLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { NotificationsSidenav } from "..";
+import { NotificationsSideNav } from "..";
 
 interface NotificationsLayoutProps {
     children?: JSX.Element | JSX.Element[];
@@ -13,7 +13,7 @@ export const NotificationsLayout: React.FC<NotificationsLayoutProps> = ({ childr
     };
     return (
         <>
-            <NotificationsSidenav path={path} updatePath={updatePathHandler} />
+            <NotificationsSideNav path={path} updatePath={updatePathHandler} />
             {children}
         </>
     );

--- a/estela-web/src/shared/layouts/ProjectLayout.tsx
+++ b/estela-web/src/shared/layouts/ProjectLayout.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 import { Layout } from "antd";
-import { Header, ProjectSidenav } from "..";
+import { Header, ProjectSideNav } from "..";
 import ExternalVerifier from "ExternalComponents/ExternalVerifier";
 
 interface RouteParams {
@@ -13,18 +13,33 @@ interface ProjectLayoutProps {
 }
 
 export const ProjectLayout: React.FC<ProjectLayoutProps> = ({ children }) => {
-    const [path, setPath] = useState("dashboard");
+    const location = useLocation();
+    const pathSegments = location.pathname.split("/");
+    let lastSegment = pathSegments[pathSegments.length - 1];
+
+    if (lastSegment === "") {
+        pathSegments.pop();
+        lastSegment = pathSegments[pathSegments.length - 1];
+    }
+
+    if (!isNaN(lastSegment)) {
+        pathSegments.pop();
+        lastSegment = pathSegments[pathSegments.length - 1];
+    }
+
+    const [path, setPath] = useState(lastSegment);
     const { projectId } = useParams<RouteParams>();
 
     const updatePathHandler = (newPath: string) => {
         setPath(newPath);
     };
+
     return (
         <Layout>
             <ExternalVerifier />
             <Header />
             <Layout className="white-background">
-                <ProjectSidenav projectId={projectId} path={path} updatePath={updatePathHandler} />
+                <ProjectSideNav projectId={projectId} path={path} updatePath={updatePathHandler} />
                 {children}
             </Layout>
         </Layout>

--- a/estela-web/src/shared/layouts/ProjectLayout.tsx
+++ b/estela-web/src/shared/layouts/ProjectLayout.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { Layout } from "antd";
 import { Header, ProjectSidenav } from "..";
+import CustomerVerifier from "ExternalComponents/CustomerVerifier";
 
 interface RouteParams {
     projectId: string;
@@ -20,6 +21,7 @@ export const ProjectLayout: React.FC<ProjectLayoutProps> = ({ children }) => {
     };
     return (
         <Layout>
+            <CustomerVerifier />
             <Header />
             <Layout className="white-background">
                 <ProjectSidenav projectId={projectId} path={path} updatePath={updatePathHandler} />

--- a/estela-web/src/shared/layouts/ProjectLayout.tsx
+++ b/estela-web/src/shared/layouts/ProjectLayout.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { Layout } from "antd";
 import { Header, ProjectSidenav } from "..";
-import CustomerVerifier from "ExternalComponents/CustomerVerifier";
+import ExternalVerifier from "ExternalComponents/ExternalVerifier";
 
 interface RouteParams {
     projectId: string;
@@ -21,7 +21,7 @@ export const ProjectLayout: React.FC<ProjectLayoutProps> = ({ children }) => {
     };
     return (
         <Layout>
-            <CustomerVerifier />
+            <ExternalVerifier />
             <Header />
             <Layout className="white-background">
                 <ProjectSidenav projectId={projectId} path={path} updatePath={updatePathHandler} />

--- a/estela-web/src/shared/notificationsSidenav/index.tsx
+++ b/estela-web/src/shared/notificationsSidenav/index.tsx
@@ -12,7 +12,7 @@ interface NotificationsInboxPropsInterface {
     updatePath: (newPath: string) => void;
 }
 
-export const NotificationsSidenav: React.FC<NotificationsInboxPropsInterface> = ({ path, updatePath }) => {
+export const NotificationsSideNav: React.FC<NotificationsInboxPropsInterface> = ({ path, updatePath }) => {
     const items: MenuProps["items"] = [
         {
             key: "1",

--- a/estela-web/src/shared/projectSidenav/index.tsx
+++ b/estela-web/src/shared/projectSidenav/index.tsx
@@ -19,7 +19,7 @@ interface ProjectSideNavPropsInterface {
     updatePath: (newPath: string) => void;
 }
 
-export const ProjectSidenav: React.FC<ProjectSideNavPropsInterface> = ({ projectId, path, updatePath }) => {
+export const ProjectSideNav: React.FC<ProjectSideNavPropsInterface> = ({ projectId, path, updatePath }) => {
     const items: MenuProps["items"] = [
         {
             key: "1",

--- a/estela-web/src/shared/projectSidenav/styles.scss
+++ b/estela-web/src/shared/projectSidenav/styles.scss
@@ -16,7 +16,7 @@ $estela-blue-low: #F6FAFD;
     }
 }
 
-.ant-menu-inline >  .ant-menu-item-selected {
+.ant-menu-inline > .ant-menu-item-selected {
     background-color: $estela-blue-low !important;
 }
 


### PR DESCRIPTION
# Description

Changes that were made:

* The modal should redirect to the Project Deploys page when creating a new project. Improve modal text in Project Deploys page so the user knows they need to make their first deploy.
* When login credentials fail, fix the Login button stuck in the loading state.
* Send users to a "Thank you" page (instead of the login page) after registering.
* The email confirmation link should redirect to a page explaining that their email is confirmed and that they can now try to log in. The page should clearly state: "You have successfully activated your account" and "You can now login" (New page)

# Issue

https://tasks.bitmaker.dev/issues/3361

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [x] New and existing tests pass locally with my changes.
- [x] If this change is a core feature, I have added thorough tests.
- [x] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bithttps://assets.grammarly.com/emoji/v1/1f91d.svgmaker.la/docs/).
- [x] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
