### PR TITLE
BITMAKER-3570 Stats module: Fix issues on stats date modal

### DIFF
--- a/estela-api/api/serializers/stats.py
+++ b/estela-api/api/serializers/stats.py
@@ -54,10 +54,22 @@ class CoverageStatsSerializer(serializers.Serializer):
 
 
 class StatsSerializer(serializers.Serializer):
+    class HHMMSSDurationField(serializers.DurationField):
+        def to_representation(self, value):
+            if not isinstance(value, timedelta):
+                return super().to_representation(value)
+
+            total_seconds = int(value.total_seconds())
+            hours = total_seconds // 3600
+            minutes = (total_seconds % 3600) // 60
+            seconds = total_seconds % 60
+
+            return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
     jobs = JobsStatsSerializer(required=False)
     pages = PagesStatsSerializer()
     items_count = serializers.IntegerField(default=0)
-    runtime = serializers.DurationField(default=timedelta(hours=0, minutes=0))
+    runtime = HHMMSSDurationField(default=timedelta(0))
     status_codes = StatusCodesStatsSerializer()
     success_rate = serializers.FloatField(default=0.0, required=False)
     logs = LogsStatsSerializer()

--- a/estela-api/api/serializers/stats.py
+++ b/estela-api/api/serializers/stats.py
@@ -54,30 +54,14 @@ class CoverageStatsSerializer(serializers.Serializer):
 
 
 class StatsSerializer(serializers.Serializer):
-    class HHMMSSDurationField(serializers.DurationField):
-        def to_representation(self, value):
-            if not isinstance(value, timedelta):
-                return super().to_representation(value)
-
-            total_seconds = int(value.total_seconds())
-            hours = total_seconds // 3600
-            minutes = (total_seconds % 3600) // 60
-            seconds = total_seconds % 60
-
-            return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
-
     jobs = JobsStatsSerializer(required=False)
     pages = PagesStatsSerializer()
     items_count = serializers.IntegerField(default=0)
-    runtime = HHMMSSDurationField(default=timedelta(0))
+    runtime = serializers.DurationField(default=timedelta(0))
     status_codes = StatusCodesStatsSerializer()
     success_rate = serializers.FloatField(default=0.0, required=False)
     logs = LogsStatsSerializer()
     coverage = CoverageStatsSerializer(required=False)
-
-
-class SpiderJobStatsSerializer(SpiderJobSerializer):
-    stats = StatsSerializer()
 
 
 class SpiderJobStatsSerializer(SpiderJobSerializer):

--- a/estela-api/api/views/stats.py
+++ b/estela-api/api/views/stats.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from re import findall
 from typing import List, Tuple
-from json import dumps
 
 from django.db.models.query import QuerySet
 from django.utils import timezone
@@ -107,16 +106,28 @@ class StatsMixin:
     }
 
     def get_parameters(self, request: Request) -> Tuple[datetime, datetime]:
-        start_date = request.query_params.get("start_date", timezone.now())
-        end_date = request.query_params.get("end_date", timezone.now())
         try:
-            if type(start_date) == str:
-                start_date = datetime.strptime(start_date, "%Y-%m-%dT%H:%M:%S.%fZ")
-            if type(end_date) == str:
-                end_date = datetime.strptime(end_date, "%Y-%m-%dT%H:%M:%S.%fZ")
+            offset = int(request.query_params.get("offset", 0))
+        except (ValueError, TypeError):
+            raise TypeError()
+
+        try:
+            start_date = request.query_params.get(
+                "start_date", timezone.now().strftime("%Y-%m-%d")
+            )
+            end_date = request.query_params.get(
+                "end_date", timezone.now().strftime("%Y-%m-%d")
+            )
+
+            start_date = datetime.strptime(start_date, "%Y-%m-%d").replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+            end_date = datetime.strptime(end_date, "%Y-%m-%d").replace(
+                hour=23, minute=59, second=59, microsecond=999999
+            )
         except ValueError:
             raise InvalidDateFormatException()
-        return start_date, end_date
+        return start_date, end_date, offset
 
     def summarize_stats_results(
         self, stats_set: List[dict], jobs_set: QuerySet[SpiderJob], offset: int
@@ -249,21 +260,21 @@ class ProjectStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
                 in_=openapi.IN_QUERY,
                 type=openapi.TYPE_STRING,
                 required=True,
-                description="Start of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-04-01T05%3A00%3A00.000Z).",
+                description="Start of date in format [%Y-%m-%d] (e.g. 2023-04-01).",
             ),
             openapi.Parameter(
                 name="end_date",
                 in_=openapi.IN_QUERY,
                 type=openapi.TYPE_STRING,
                 required=True,
-                description="End of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-06-02T04%3A59%3A59.999Z).",
+                description="End of date in format [%Y-%m-%d] (e.g. 2023-06-02).",
             ),
             openapi.Parameter(
                 name="offset",
                 in_=openapi.IN_QUERY,
                 type=openapi.TYPE_INTEGER,
                 required=False,
-                description="Offset from UTC time in minutes.",
+                description="Offset between your local timezone and UTC in 'minutes'.",
             ),
         ],
         responses={
@@ -275,8 +286,7 @@ class ProjectStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
     )
     def list(self, request: Request, *args, **kwargs):
         try:
-            start_date, end_date = self.get_parameters(request)
-            offset = int(request.query_params.get("offset", 0))
+            start_date, end_date, offset = self.get_parameters(request)
         except (ValueError, TypeError):
             return Response(
                 {"error": "Invalid 'offset' parameter. Must be an integer."},
@@ -284,6 +294,10 @@ class ProjectStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
             )
         except InvalidDateFormatException as e:
             return Response({"error": str(e.detail)}, status=e.status_code)
+
+        start_date, end_date = start_date + timedelta(
+            minutes=offset
+        ), end_date + timedelta(minutes=offset)
 
         if not spiderdata_db_client.get_connection():
             raise DataBaseError({"error": errors.UNABLE_CONNECT_DB})
@@ -312,8 +326,7 @@ class ProjectStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
             if stat_serializer.is_valid(raise_exception=True):
                 response_schema.append(
                     {
-                        "date": datetime.strptime(date_stat, "%Y-%m-%d")
-                        + timedelta(minutes=offset),
+                        "date": datetime.strptime(date_stat, "%Y-%m-%d"),
                         "stats": stat_serializer.data,
                     }
                 )
@@ -341,6 +354,13 @@ class ProjectStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
                 required=True,
                 description="End of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-06-02T04%3A59%3A59.999Z).",
             ),
+            openapi.Parameter(
+                name="offset",
+                in_=openapi.IN_QUERY,
+                type=openapi.TYPE_INTEGER,
+                required=False,
+                description="Offset between your local timezone and UTC in 'minutes'.",
+            ),
         ],
         responses={
             status.HTTP_200_OK: openapi.Response(
@@ -352,9 +372,18 @@ class ProjectStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
     @action(methods=["GET"], detail=False)
     def spiders(self, request: Request, *args, **kwargs):
         try:
-            start_date, end_date = self.get_parameters(request)
+            start_date, end_date, offset = self.get_parameters(request)
+        except (ValueError, TypeError):
+            return Response(
+                {"error": "Invalid 'offset' parameter. Must be an integer."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except InvalidDateFormatException as e:
             return Response({"error": str(e.detail)}, status=e.status_code)
+
+        start_date, end_date = start_date + timedelta(
+            minutes=offset
+        ), end_date + timedelta(minutes=offset)
 
         paginator = PageNumberPagination()
         paginator.page = request.query_params.get("page", 1)
@@ -364,88 +393,12 @@ class ProjectStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
         paginator.max_page_size = self.MAX_PAGINATION_SIZE
 
         spiders_set = Spider.objects.filter(
-            jobs__created__range=[start_date, end_date]
+            project=kwargs["pid"], jobs__created__range=[start_date, end_date]
         ).distinct()
         paginated_spiders_set = paginator.paginate_queryset(spiders_set, request)
 
         serializer = SpiderSerializer(paginated_spiders_set, many=True)
         return paginator.get_paginated_response(serializer.data)
-
-    @swagger_auto_schema(
-        operation_description="Retrieve all the jobs of a spider executed in a range of dates.",
-        manual_parameters=[
-            openapi.Parameter(
-                name="start_date",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
-                required=True,
-                description="Start of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-04-01T05%3A00%3A00.000Z).",
-            ),
-            openapi.Parameter(
-                name="end_date",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
-                required=True,
-                description="End of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-06-02T04%3A59%3A59.999Z).",
-            ),
-            openapi.Parameter(
-                name="spider",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_INTEGER,
-                required=True,
-                description="The spider ID related to the jobs.",
-            ),
-        ],
-        responses={
-            status.HTTP_200_OK: openapi.Response(
-                description="Paginated jobs belonging to a spider in a range of time",
-                schema=JobsPaginationSerializer(),
-            ),
-        },
-    )
-    @action(methods=["GET"], detail=False)
-    def jobs(self, request: Request, *args, **kwargs):
-        try:
-            start_date, end_date = self.get_parameters(request)
-            spider = int(request.query_params.get("spider"))
-        except (ValueError, TypeError):
-            return Response(
-                {"error": "Invalid 'spider' parameter. Must be an integer."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        except InvalidDateFormatException as e:
-            return Response({"error": str(e.detail)}, status=e.status_code)
-
-        if not spiderdata_db_client.get_connection():
-            raise DataBaseError({"error": errors.UNABLE_CONNECT_DB})
-
-        paginator = PageNumberPagination()
-        paginator.page = request.query_params.get("page", 1)
-        paginator.page_size = request.query_params.get(
-            "page_size", self.DEFAULT_PAGINATION_SIZE
-        )
-        paginator.max_page_size = self.MAX_PAGINATION_SIZE
-
-        jobs_set = SpiderJob.objects.filter(
-            spider=spider, created__range=[start_date, end_date]
-        )
-
-        paginated_jobs_set = paginator.paginate_queryset(jobs_set, request)
-
-        jobs_stats_ids: List[str] = [
-            "{}-{}-job_stats".format(job.spider.sid, job.jid)
-            for job in paginated_jobs_set
-        ]
-        stats_set: List[dict] = spiderdata_db_client.get_jobs_set_stats(
-            kwargs["pid"], jobs_stats_ids
-        )
-        stats_results: dict = self.parse_jobs_stats(stats_set=stats_set)
-        serializer = SpiderJobSerializer(paginated_jobs_set, many=True)
-        response_schema = []
-        for job in serializer.data:
-            job_id = job.get("jid", None)
-            response_schema.append({**job, "stats": stats_results[job_id]})
-        return paginator.get_paginated_response(response_schema)
 
 
 class SpidersJobsStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
@@ -477,7 +430,7 @@ class SpidersJobsStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
                 in_=openapi.IN_QUERY,
                 type=openapi.TYPE_INTEGER,
                 required=False,
-                description="Offset from UTC time in minutes.",
+                description="Offset between your local timezone and UTC in 'minutes'.",
             ),
         ],
         responses={
@@ -489,8 +442,7 @@ class SpidersJobsStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
     )
     def list(self, request: Request, *args, **kwargs):
         try:
-            start_date, end_date = self.get_parameters(request)
-            offset = int(request.query_params.get("offset", 0))
+            start_date, end_date, offset = self.get_parameters(request)
         except (ValueError, TypeError):
             return Response(
                 {"error": "Invalid 'offset' parameter. Must be an integer."},
@@ -498,6 +450,10 @@ class SpidersJobsStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
             )
         except InvalidDateFormatException as e:
             return Response({"error": str(e.detail)}, status=e.status_code)
+
+        start_date, end_date = start_date + timedelta(
+            minutes=offset
+        ), end_date + timedelta(minutes=offset)
 
         if not spiderdata_db_client.get_connection():
             raise ConnectionError({"error": errors.UNABLE_CONNECT_DB})
@@ -525,8 +481,7 @@ class SpidersJobsStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
             if stat_serializer.is_valid():
                 response_schema.append(
                     {
-                        "date": datetime.strptime(date_stat, "%Y-%m-%d")
-                        + timedelta(minutes=offset),
+                        "date": datetime.strptime(date_stat, "%Y-%m-%d"),
                         "stats": stat_serializer.data,
                     }
                 )
@@ -554,11 +509,11 @@ class SpidersJobsStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
                 description="End of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-06-02T04%3A59%3A59.999Z).",
             ),
             openapi.Parameter(
-                name="spider",
+                name="offset",
                 in_=openapi.IN_QUERY,
                 type=openapi.TYPE_INTEGER,
-                required=True,
-                description="The spider ID related to the jobs.",
+                required=False,
+                description="Offset between your local timezone and UTC in 'minutes'.",
             ),
         ],
         responses={
@@ -571,9 +526,18 @@ class SpidersJobsStatsViewSet(BaseViewSet, StatsMixin, mixins.ListModelMixin):
     @action(methods=["GET"], detail=False)
     def jobs(self, request: Request, *args, **kwargs):
         try:
-            start_date, end_date = self.get_parameters(request)
+            start_date, end_date, offset = self.get_parameters(request)
+        except (ValueError, TypeError):
+            return Response(
+                {"error": "Invalid 'offset' parameter. Must be an integer."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except InvalidDateFormatException as e:
             return Response({"error": str(e.detail)}, status=e.status_code)
+
+        start_date, end_date = start_date + timedelta(
+            minutes=offset
+        ), end_date + timedelta(minutes=offset)
 
         if not spiderdata_db_client.get_connection():
             raise DataBaseError({"error": errors.UNABLE_CONNECT_DB})

--- a/estela-api/api/views/stats.py
+++ b/estela-api/api/views/stats.py
@@ -151,16 +151,13 @@ class StatsMixin:
             stats_results[date_str]["jobs"]["total_jobs"] += 1
             for (key, value) in self.stats_mapping["jobs"].items():
                 stats_results[date_str]["jobs"][key] += int(job.status == value)
+            stats_results[date_str]["runtime"] += job.lifespan
 
         for stats in stats_set:
             job_id = int(findall(r"\d+", stats["_id"])[1])
             date_str = jobs_offset[job_id]
             stats_results[date_str]["items_count"] += stats.get(
                 self.stats_mapping["items_count"], 0
-            )
-
-            stats_results[date_str]["runtime"] += timedelta(
-                seconds=stats.get(self.stats_mapping["runtime"], 0.0)
             )
 
             stats_results[date_str]["pages"]["scraped_pages"] += stats.get(

--- a/estela-api/docs/api.yaml
+++ b/estela-api/docs/api.yaml
@@ -1320,17 +1320,17 @@ paths:
           type: integer
         - name: start_date
           in: query
-          description: Start of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-04-01T05%3A00%3A00.000Z).
+          description: Start of date in format [%Y-%m-%d] (e.g. 2023-04-01).
           required: true
           type: string
         - name: end_date
           in: query
-          description: End of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-06-02T04%3A59%3A59.999Z).
+          description: End of date in format [%Y-%m-%d] (e.g. 2023-06-02).
           required: true
           type: string
         - name: offset
           in: query
-          description: Offset from UTC time in minutes.
+          description: Offset between your local timezone and UTC in 'minutes'.
           required: false
           type: integer
       responses:
@@ -1340,48 +1340,6 @@ paths:
             type: array
             items:
               $ref: '#/definitions/ProjectStats'
-      tags:
-        - api
-    parameters:
-      - name: pid
-        in: path
-        required: true
-        type: string
-  /api/stats/{pid}/jobs:
-    get:
-      operationId: api_stats_jobs
-      description: Retrieve all the jobs of a spider executed in a range of dates.
-      parameters:
-        - name: page
-          in: query
-          description: A page number within the paginated result set.
-          required: false
-          type: integer
-        - name: page_size
-          in: query
-          description: Number of results to return per page.
-          required: false
-          type: integer
-        - name: start_date
-          in: query
-          description: Start of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-04-01T05%3A00%3A00.000Z).
-          required: true
-          type: string
-        - name: end_date
-          in: query
-          description: End of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-06-02T04%3A59%3A59.999Z).
-          required: true
-          type: string
-        - name: spider
-          in: query
-          description: The spider ID related to the jobs.
-          required: true
-          type: integer
-      responses:
-        '200':
-          description: Paginated jobs belonging to a spider in a range of time
-          schema:
-            $ref: '#/definitions/JobsPagination'
       tags:
         - api
     parameters:
@@ -1417,7 +1375,7 @@ paths:
           type: string
         - name: offset
           in: query
-          description: Offset from UTC time in minutes.
+          description: Offset between your local timezone and UTC in 'minutes'.
           required: false
           type: integer
       responses:
@@ -1463,10 +1421,10 @@ paths:
           description: End of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-06-02T04%3A59%3A59.999Z).
           required: true
           type: string
-        - name: spider
+        - name: offset
           in: query
-          description: The spider ID related to the jobs.
-          required: true
+          description: Offset between your local timezone and UTC in 'minutes'.
+          required: false
           type: integer
       responses:
         '200':
@@ -1509,6 +1467,11 @@ paths:
           description: End of date in UTC format [%Y-%m-%dT%H:%M:%S.%fZ] (e.g. 2023-06-02T04%3A59%3A59.999Z).
           required: true
           type: string
+        - name: offset
+          in: query
+          description: Offset between your local timezone and UTC in 'minutes'.
+          required: false
+          type: integer
       responses:
         '200':
           description: Paginated spiders launched in a range of time
@@ -2771,6 +2734,18 @@ definitions:
         format: date
       stats:
         $ref: '#/definitions/Stats'
+  SpidersStats:
+    required:
+      - date
+      - stats
+    type: object
+    properties:
+      date:
+        title: Date
+        type: string
+        format: date
+      stats:
+        $ref: '#/definitions/Stats'
   SpiderJobStats:
     required:
       - stats
@@ -2887,18 +2862,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/SpiderJobStats'
-  SpidersStats:
-    required:
-      - date
-      - stats
-    type: object
-    properties:
-      date:
-        title: Date
-        type: string
-        format: date
-      stats:
-        $ref: '#/definitions/Stats'
   SpidersPagination:
     required:
       - count

--- a/estela-web/src/components/Stats/ChartsModalSection.tsx
+++ b/estela-web/src/components/Stats/ChartsModalSection.tsx
@@ -40,7 +40,7 @@ const datasetsGenerator = (statOption: StatType, stats: SpiderJobStats | SpiderJ
             return [
                 {
                     label: "items",
-                    data: [sumArr(stats.map((jobsStats) => jobsStats.stats?.itemsCount ?? 0))],
+                    data: stats.map((jobsStats) => jobsStats.stats?.itemsCount ?? 0),
                     backgroundColor: "#32C3A4",
                 },
             ];
@@ -48,9 +48,7 @@ const datasetsGenerator = (statOption: StatType, stats: SpiderJobStats | SpiderJ
             return [
                 {
                     label: "runtime",
-                    data: [
-                        sumArr(stats.map((jobsStats) => parseDurationToSeconds(jobsStats.stats?.runtime?.toString()))),
-                    ],
+                    data: stats.map((jobsStats) => parseDurationToSeconds(jobsStats.stats?.runtime?.toString())),
                     backgroundColor: "#32C3A4",
                 },
             ];
@@ -487,9 +485,12 @@ interface ChartsModalSectionProps {
 }
 export class ChartsModalSection extends Component<ChartsModalSectionProps, unknown> {
     labelsGenerator = (statOption: StatType) => {
+        const { stats } = this.props;
         if (statOption === StatType.PAGES) return ["scraped", "missed"];
-        else if (statOption === StatType.ITEMS) return ["items"];
-        else if (statOption === StatType.RUNTIME) return ["runtime"];
+        else if (statOption === StatType.ITEMS)
+            return Array.isArray(stats) ? stats.map(({ jid }) => `job ${jid}`) : ["items"];
+        else if (statOption === StatType.RUNTIME)
+            return Array.isArray(stats) ? stats.map(({ jid }) => `job ${jid}`) : ["runtime"];
         else if (statOption === StatType.SUCCESS_RATE) return ["job success rate"];
         else if (statOption === StatType.STATUS_CODE) return ["200", "301", "302", "401", "403", "404", "429", "500"];
         else if (statOption === StatType.COVERAGE) return ["coverage"];

--- a/estela-web/src/components/Stats/ChartsModalSection.tsx
+++ b/estela-web/src/components/Stats/ChartsModalSection.tsx
@@ -15,7 +15,7 @@ import { StatType } from "../../shared";
 import { SpiderJobStats } from "../../services";
 import { Tabs } from "antd";
 import "./ChartsSection.scss";
-import { parseDurationToSeconds, setValArr, sumArr } from "../../utils";
+import { durationToSeconds, parseDuration, setValArr, sumArr } from "../../utils";
 import moment from "moment";
 import { MinMaxStatCard } from "./MinMaxStatCard";
 
@@ -48,7 +48,7 @@ const datasetsGenerator = (statOption: StatType, stats: SpiderJobStats | SpiderJ
             return [
                 {
                     label: "runtime",
-                    data: stats.map((jobsStats) => parseDurationToSeconds(jobsStats.stats?.runtime?.toString())),
+                    data: stats.map((jobsStats) => durationToSeconds(parseDuration(jobsStats.lifespan?.toString()))),
                     backgroundColor: "#32C3A4",
                 },
             ];

--- a/estela-web/src/components/Stats/ChartsSection.tsx
+++ b/estela-web/src/components/Stats/ChartsSection.tsx
@@ -16,6 +16,7 @@ import { ProjectStats, SpidersStats } from "../../services";
 import { Empty, Tabs } from "antd";
 import moment from "moment";
 import "./ChartsSection.scss";
+import { durationToSeconds, parseDuration } from "../../utils";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
@@ -84,7 +85,9 @@ const getRuntimeDataset = (statsData: ProjectStats[]) => {
     return [
         {
             label: "Runtime (seconds)",
-            data: statsData.map((statData) => statData.stats.runtime ?? 0),
+            data: statsData.map((statData) =>
+                durationToSeconds(parseDuration(statData.stats.runtime?.toString() || "0:00:00")),
+            ),
             backgroundColor: "#32C3A4",
         },
     ];

--- a/estela-web/src/components/Stats/ProjectHealth.tsx
+++ b/estela-web/src/components/Stats/ProjectHealth.tsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { Doughnut } from "react-chartjs-2";
 import { Card, Space, Typography, Tooltip as TooltipAntd, Divider } from "antd";
 import { Spin } from "../../shared";
-import { BytesMetric, formatSecondsToHHMMSS } from "../../utils";
+import { BytesMetric, durationToString, parseDuration } from "../../utils";
 import { Chart as ChartJS, CategoryScale, Title, Tooltip, Legend, ArcElement } from "chart.js";
 import Help from "../../assets/icons/help.svg";
 import { ProjectStats } from "../../services";
@@ -216,7 +216,7 @@ export class ProjectHealth extends Component<ProjectHealthProps, ProjectHealthSt
                             <div className="flex items-center justify-between space-x-4">
                                 <Text className="text-sm text-estela-black-medium break-words">Processing time</Text>
                                 <Text className="text-base text-estela-black-full break-words">
-                                    {formatSecondsToHHMMSS(processingTime)}
+                                    {durationToString(parseDuration(processingTime.toString()))}
                                 </Text>
                             </div>
                             <div className="flex items-center justify-between space-x-4">

--- a/estela-web/src/components/Stats/StatsDateModalContent.tsx
+++ b/estela-web/src/components/Stats/StatsDateModalContent.tsx
@@ -10,7 +10,7 @@ import "./StatsDateModalContent.scss";
 import moment from "moment";
 import { Link } from "react-router-dom";
 import { ChartsModalSection } from "./ChartsModalSection";
-import { formatBytes, formatSecondsToHHMMSS, parseDurationToSeconds } from "../../utils";
+import { durationToSeconds, durationToString, formatBytes, parseDuration, secondsToDuration } from "../../utils";
 
 interface StatsDateModalContentState {
     activeSpider: Spider;
@@ -155,7 +155,7 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
         const jobsItems = jobs.results.map((job) => {
             return {
                 label: <p className="text-estela-black-full text-right">Job {job.jid}</p>,
-                key: `job-${job.jid}`,
+                key: `${job.jid}`,
                 children: <ChartsModalSection pid={pid} stats={job} pages statusCodes logs />,
             };
         });
@@ -169,12 +169,16 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
         const spiderBandwidth = formatBytes(
             jobs.results.reduce((acc, curr) => acc + (curr.totalResponseBytes ?? 0), 0),
         );
-        const spiderProcessingTime = formatSecondsToHHMMSS(
-            Math.round(
-                jobs.results.reduce((acc, curr) => acc + parseDurationToSeconds(curr.stats.runtime?.toString()), 0),
+        const spiderProcessingTime = durationToString(
+            secondsToDuration(
+                Math.round(
+                    jobs.results.reduce(
+                        (acc, curr) => acc + durationToSeconds(parseDuration(curr.lifespan?.toString())),
+                        0,
+                    ),
+                ),
             ),
         );
-
         return (
             <>
                 {overviewTabSelected && activeSpider.sid ? (
@@ -204,13 +208,7 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
                             <div className="flex items-center gap-x-5 py-5">
                                 <div className="w-3/12 rounded-lg border-2 border-estela-states-green-full p-3 bg-estela-blue-low">
                                     <p className="text-center text-estela-states-green-full text-sm font-bold">
-                                        {isNaN(Math.round(parseDurationToSeconds(activeJob.stats.runtime?.toString())))
-                                            ? "00:00:00"
-                                            : formatSecondsToHHMMSS(
-                                                  Math.round(
-                                                      parseDurationToSeconds(activeJob.stats.runtime?.toString()),
-                                                  ),
-                                              )}
+                                        {activeJob.lifespan || "0:00:00"}
                                     </p>
                                     <p title="Duration" className="text-center text-estela-states-green-full text-sm">
                                         Dur.

--- a/estela-web/src/components/Stats/StatsDateModalContent.tsx
+++ b/estela-web/src/components/Stats/StatsDateModalContent.tsx
@@ -10,7 +10,7 @@ import "./StatsDateModalContent.scss";
 import moment from "moment";
 import { Link } from "react-router-dom";
 import { ChartsModalSection } from "./ChartsModalSection";
-import { formatBytes, parseDurationToSeconds } from "../../utils";
+import { formatBytes, formatSecondsToHHMMSS, parseDurationToSeconds } from "../../utils";
 
 interface StatsDateModalContentState {
     activeSpider: Spider;
@@ -37,6 +37,7 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
     abortController = new AbortController();
     jobPageSize = 10;
     spiderPageSize = 10;
+    isMounted = false;
 
     state: StatsDateModalContentState = {
         activeSpider: {} as Spider,
@@ -51,24 +52,30 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
     };
 
     async componentDidMount(): Promise<void> {
-        const activeSpider = await this.retrieveSpiders(1);
-        if (activeSpider) this.retrieveJobsSpider(activeSpider.sid ?? 0, 1);
-    }
-
-    async componentDidUpdate(prevProps: Readonly<StatsDateModalContentProps>) {
-        const { startDate, endDate } = this.props;
-        if (prevProps.startDate !== startDate && prevProps.endDate !== endDate) {
+        this.isMounted = true;
+        if (this.isMounted) {
             const activeSpider = await this.retrieveSpiders(1);
             if (activeSpider) this.retrieveJobsSpider(activeSpider.sid ?? 0, 1);
         }
     }
 
+    async componentDidUpdate(prevProps: Readonly<StatsDateModalContentProps>) {
+        const { startDate, endDate } = this.props;
+        if (prevProps.startDate !== startDate && prevProps.endDate !== endDate) {
+            if (this.isMounted) {
+                const activeSpider = await this.retrieveSpiders(1);
+                if (activeSpider) this.retrieveJobsSpider(activeSpider.sid ?? 0, 1);
+            }
+        }
+    }
+
     componentWillUnmount(): void {
+        this.isMounted = false;
         this.abortController.abort();
     }
 
     retrieveSpiders = async (page?: number) => {
-        this.setState({ loadedSpiders: false, overviewTabSelected: true });
+        this.isMounted && this.setState({ loadedSpiders: false, overviewTabSelected: true });
         try {
             const { currSpidersPage } = this.state;
             const { pid, startDate, endDate, apiService } = this.props;
@@ -76,14 +83,15 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
                 pid: pid,
                 startDate: startDate,
                 endDate: endDate,
+                offset: new Date().getTimezoneOffset(),
                 pageSize: this.spiderPageSize,
                 page: page || currSpidersPage,
             });
-            if (spiders.results.length === 0 && !this.abortController.signal.aborted) {
+            if (spiders.results.length === 0 && !this.abortController.signal.aborted && this.isMounted) {
                 this.setState({ loadedSpiders: true, spiders: spiders });
                 return null;
             }
-            if (!this.abortController.signal.aborted) {
+            if (!this.abortController.signal.aborted && this.isMounted) {
                 this.setState({
                     loadedSpiders: true,
                     spiders: spiders,
@@ -99,26 +107,27 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
     };
 
     retrieveJobsSpider = async (spider: number, page?: number) => {
-        this.setState({ loadedJobs: false, overviewTabSelected: true });
+        this.isMounted && this.setState({ loadedJobs: false, overviewTabSelected: true });
         try {
             const { pid, startDate, endDate, apiService } = this.props;
             const { activeSpider, currJobsPage } = this.state;
 
             if (!activeSpider.sid) throw new Error("No active spider found");
-            const jobs = apiService.apiStatsJobs({
+            const jobs = apiService.apiStatsSpiderJobs({
                 pid: pid,
-                spider: spider,
+                sid: `${spider}`,
                 startDate: startDate,
                 endDate: endDate,
+                offset: new Date().getTimezoneOffset(),
                 pageSize: this.jobPageSize,
                 page: page || currJobsPage,
             });
             jobs.then((jobs) => {
-                if (jobs.results.length === 0 && !this.abortController.signal.aborted) {
+                if (jobs.results.length === 0 && !this.abortController.signal.aborted && this.isMounted) {
                     this.setState({ loadedJobs: true, jobs: jobs });
                     return;
                 }
-                if (!this.abortController.signal.aborted) {
+                if (!this.abortController.signal.aborted && this.isMounted) {
                     this.setState({ loadedJobs: true, jobs: jobs, currJobsPage: page || currJobsPage });
                     return;
                 }
@@ -146,7 +155,7 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
         const jobsItems = jobs.results.map((job) => {
             return {
                 label: <p className="text-estela-black-full text-right">Job {job.jid}</p>,
-                key: `${job.jid}`,
+                key: `job-${job.jid}`,
                 children: <ChartsModalSection pid={pid} stats={job} pages statusCodes logs />,
             };
         });
@@ -160,8 +169,10 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
         const spiderBandwidth = formatBytes(
             jobs.results.reduce((acc, curr) => acc + (curr.totalResponseBytes ?? 0), 0),
         );
-        const spiderProcessingTime = Math.round(
-            jobs.results.reduce((acc, curr) => acc + parseDurationToSeconds(curr.stats.runtime?.toString()), 0),
+        const spiderProcessingTime = formatSecondsToHHMMSS(
+            Math.round(
+                jobs.results.reduce((acc, curr) => acc + parseDurationToSeconds(curr.stats.runtime?.toString()), 0),
+            ),
         );
 
         return (
@@ -192,24 +203,30 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
                         <div className="divide-y">
                             <div className="flex items-center gap-x-5 py-5">
                                 <div className="w-3/12 rounded-lg border-2 border-estela-states-green-full p-3 bg-estela-blue-low">
-                                    <p className="text-center text-estela-states-green-full text-lg font-bold">
+                                    <p className="text-center text-estela-states-green-full text-sm font-bold">
                                         {isNaN(Math.round(parseDurationToSeconds(activeJob.stats.runtime?.toString())))
-                                            ? "none"
-                                            : Math.round(parseDurationToSeconds(activeJob.stats.runtime?.toString()))}
+                                            ? "00:00:00"
+                                            : formatSecondsToHHMMSS(
+                                                  Math.round(
+                                                      parseDurationToSeconds(activeJob.stats.runtime?.toString()),
+                                                  ),
+                                              )}
                                     </p>
-                                    <p className="text-center text-estela-states-green-full text-sm">Sec</p>
+                                    <p title="Duration" className="text-center text-estela-states-green-full text-sm">
+                                        Dur.
+                                    </p>
                                 </div>
                                 <div className="w-9/12">
                                     <p className="text-estela-black-full text-sm font-medium">Runtime</p>
                                     <p className="text-estela-black-medium text-xs">
-                                        How much your spider delayed (seconds).
+                                        How much your spider delayed (HH:MM:SS).
                                     </p>
                                 </div>
                             </div>
                             <div className="flex items-center gap-x-5 py-5">
                                 <div className="w-3/12 rounded-lg border-2 border-estela-states-green-full p-3 bg-estela-blue-low">
                                     <p className="text-center text-estela-states-green-full text-lg font-bold">
-                                        {activeJob.itemCount || "none"}
+                                        {activeJob.itemCount || 0}
                                     </p>
                                     <p className="text-center text-estela-states-green-full text-sm">Items</p>
                                 </div>
@@ -267,10 +284,12 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
                             </div>
                             <div className="flex items-center gap-x-5 py-5">
                                 <div className="w-3/12 rounded-lg border-2 border-estela-blue-full p-3 bg-estela-blue-low">
-                                    <p className="text-center text-estela-blue-full text-lg font-bold">
+                                    <p className="text-center text-estela-blue-full text-sm font-bold">
                                         {spiderProcessingTime}
                                     </p>
-                                    <p className="text-center text-estela-blue-full text-sm">Sec</p>
+                                    <p title="Duration" className="text-center text-estela-blue-full text-sm">
+                                        Dur.
+                                    </p>
                                 </div>
                                 <div className="w-9/12">
                                     <p className="text-estela-black-full text-sm font-medium">Processing time</p>
@@ -296,20 +315,22 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
                         <>
                             <Row className="flex justify-center items-center py-4 gap-32">
                                 <div
+                                    title="previous date"
                                     className="stroke-estela-white-full hover:cursor-pointer"
                                     onClick={() => prevDate()}
                                 >
                                     <ArrowLeft className="h-6 w-6 hover:drop-shadow-md hover:brightness-100" />
                                 </div>
                                 <div className="text-estela-white-full text-sm">
-                                    <p className="text-center">{moment.utc(startDate).local().format("dddd")}</p>
-                                    <p className="text-center">
-                                        {moment.utc(startDate).local().format("DD MMMM, YYYY")}
-                                    </p>
+                                    <p className="text-center">{moment(startDate).format("dddd")}</p>
+                                    <p className="text-center">{moment(startDate).format("DD MMMM, YYYY")}</p>
                                 </div>
                                 <div
+                                    title="next date"
                                     className="stroke-estela-white-full hover:cursor-pointer"
-                                    onClick={() => nextDate()}
+                                    onClick={() => {
+                                        nextDate();
+                                    }}
                                 >
                                     <ArrowRight className="h-6 w-6" />
                                 </div>

--- a/estela-web/src/components/Stats/StatsTableSection.tsx
+++ b/estela-web/src/components/Stats/StatsTableSection.tsx
@@ -2,12 +2,12 @@ import React, { Component } from "react";
 import { Modal, Row, Table } from "antd";
 import moment from "moment";
 import type { ColumnsType } from "antd/es/table";
-import { formatSecondsToHHMMSS } from "../../utils";
 import { ApiApi, ProjectStats, SpidersStats } from "../../services";
 import Cross from "../../assets/icons/cross.svg";
 import Expand from "../../assets/icons/expand.svg";
 import "./StatsTableSection.scss";
 import { StatsDateModalContent } from "./StatsDateModalContent";
+import { durationToString, parseDuration } from "../../utils";
 
 interface StatsTableDataType {
     key: string;
@@ -149,8 +149,9 @@ export class StatsTableSection extends Component<StatsTableSectionProps, StatsTa
             key: "runtime",
             align: "center",
             render: (_, { statsDate }) => {
-                const runtime = formatSecondsToHHMMSS(statsDate.stats.runtime ?? 0);
-                return <p className="text-black text-xs font-normal">{runtime}</p>;
+                const runtime = parseDuration(statsDate.stats.runtime?.toString() || "0:00:00");
+                runtime.milliseconds = 0;
+                return <p className="text-black text-xs font-normal">{durationToString(runtime)}</p>;
             },
             sorter: (statA, statB) => {
                 const runtimeA = statA.statsDate.stats.runtime ?? 0;

--- a/estela-web/src/components/Stats/StatsTableSection.tsx
+++ b/estela-web/src/components/Stats/StatsTableSection.tsx
@@ -47,9 +47,10 @@ export class StatsTableSection extends Component<StatsTableSectionProps, StatsTa
                     <div
                         title="see details"
                         onClick={() => {
+                            const dateString = statsDate.date.toLocaleDateString();
                             const [startDate, endDate] = [
-                                moment(statsDate.date).startOf("day").utc().toISOString(),
-                                moment(statsDate.date).endOf("day").utc().toISOString(),
+                                moment(dateString, "M/D/YYYY").format("YYYY-MM-DD"),
+                                moment(dateString, "M/D/YYYY").format("YYYY-MM-DD"),
                             ];
                             this.setState({
                                 openDateModal: true,
@@ -249,9 +250,10 @@ export class StatsTableSection extends Component<StatsTableSectionProps, StatsTa
                     onRow={(record, rowIndex) => {
                         return {
                             onClick: () => {
+                                const dateString = record.statsDate.date.toLocaleDateString();
                                 const [startDate, endDate] = [
-                                    moment(record.statsDate.date).startOf("day").utc().toISOString(),
-                                    moment(record.statsDate.date).endOf("day").utc().toISOString(),
+                                    moment(dateString, "M/D/YYYY").format("YYYY-MM-DD"),
+                                    moment(dateString, "M/D/YYYY").format("YYYY-MM-DD"),
                                 ];
                                 this.setState({
                                     openDateModal: true,
@@ -280,38 +282,28 @@ export class StatsTableSection extends Component<StatsTableSectionProps, StatsTa
                         startDate={startDateModal}
                         endDate={endDateModal}
                         nextDate={() => {
-                            if (focusStatsDateIndex < stats.length - 1) {
+                            if (focusStatsDateIndex > 0) {
+                                const dateString = stats[focusStatsDateIndex - 1].date.toLocaleDateString();
                                 const [startDate, endDate] = [
-                                    moment(stats[focusStatsDateIndex + 1].date)
-                                        .startOf("day")
-                                        .utc()
-                                        .toISOString(),
-                                    moment(stats[focusStatsDateIndex + 1].date)
-                                        .endOf("day")
-                                        .utc()
-                                        .toISOString(),
+                                    moment(dateString, "M/D/YYYY").startOf("day").format("YYYY-MM-DD"),
+                                    moment(dateString, "M/D/YYYY").endOf("day").format("YYYY-MM-DD"),
                                 ];
                                 this.setState({
-                                    focusStatsDateIndex: focusStatsDateIndex + 1,
+                                    focusStatsDateIndex: focusStatsDateIndex - 1,
                                     startDateModal: startDate,
                                     endDateModal: endDate,
                                 });
                             }
                         }}
                         prevDate={() => {
-                            if (focusStatsDateIndex > 0) {
+                            if (focusStatsDateIndex < stats.length - 1) {
+                                const dateString = stats[focusStatsDateIndex + 1].date.toLocaleDateString();
                                 const [startDate, endDate] = [
-                                    moment(stats[focusStatsDateIndex - 1].date)
-                                        .startOf("day")
-                                        .utc()
-                                        .toISOString(),
-                                    moment(stats[focusStatsDateIndex - 1].date)
-                                        .endOf("day")
-                                        .utc()
-                                        .toISOString(),
+                                    moment(dateString, "M/D/YYYY").format("YYYY-MM-DD"),
+                                    moment(dateString, "M/D/YYYY").format("YYYY-MM-DD"),
                                 ];
                                 this.setState({
-                                    focusStatsDateIndex: focusStatsDateIndex - 1,
+                                    focusStatsDateIndex: focusStatsDateIndex + 1,
                                     startDateModal: startDate,
                                     endDateModal: endDate,
                                 });

--- a/estela-web/src/pages/JobDetailPage/index.tsx
+++ b/estela-web/src/pages/JobDetailPage/index.tsx
@@ -26,7 +26,7 @@ import { Link, RouteComponentProps } from "react-router-dom";
 import "./styles.scss";
 import history from "../../history";
 import { ApiService } from "../../services";
-import { BytesMetric, formatSecondsToHHMMSS, formatBytes } from "../../utils";
+import { BytesMetric, durationToString, formatBytes, secondsToDuration } from "../../utils";
 import Copy from "../../assets/icons/copy.svg";
 import Pause from "../../assets/icons/pause.svg";
 import Add from "../../assets/icons/add.svg";
@@ -946,7 +946,7 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
                         <Row className="grid grid-cols-1 py-1 px-2 mt-3">
                             <Col>
                                 <Text className="font-bold text-estela-black-full text-lg">
-                                    {formatSecondsToHHMMSS(lifespan ?? 0)}
+                                    {durationToString(secondsToDuration(lifespan || 0))}
                                 </Text>
                             </Col>
                             <Col>

--- a/estela-web/src/pages/ProjectDashboardPage/index.tsx
+++ b/estela-web/src/pages/ProjectDashboardPage/index.tsx
@@ -5,7 +5,7 @@ import "./styles.scss";
 import { ApiService, AuthService } from "../../services";
 import Copy from "../../assets/icons/copy.svg";
 import { ApiProjectsReadRequest, Project, ProjectUsage, ProjectStats } from "../../services/api";
-import { BytesMetric, formatBytes, parseDurationToSeconds } from "../../utils";
+import { BytesMetric, formatBytes } from "../../utils";
 import { resourceNotAllowedNotification, Spin } from "../../shared";
 import { UserContext, UserContextProps } from "../../context";
 import moment from "moment";
@@ -120,10 +120,6 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
             })
             .then(
                 (response: ProjectStats[]) => {
-                    response.forEach((stat) => {
-                        if (stat.stats.runtime)
-                            stat.stats.runtime = parseDurationToSeconds(stat.stats.runtime.toString());
-                    });
                     this.setState({
                         projectStats: [...response],
                         loadedStats: true,

--- a/estela-web/src/pages/ProjectDashboardPage/index.tsx
+++ b/estela-web/src/pages/ProjectDashboardPage/index.tsx
@@ -51,8 +51,8 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
         current: 0,
         loadedStats: false,
         projectStats: [],
-        statsStartDate: moment().subtract(7, "days").startOf("day").utc(),
-        statsEndDate: moment().utc(),
+        statsStartDate: moment().subtract(7, "days").startOf("day"),
+        statsEndDate: moment(),
     };
     apiService = ApiService();
     projectId: string = this.props.match.params.projectId;
@@ -114,8 +114,8 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
         await this.apiService
             .apiStatsList({
                 pid: this.projectId,
-                startDate: !startDate ? statsStartDate.toISOString() : startDate,
-                endDate: !endDate ? statsEndDate.toISOString() : endDate,
+                startDate: !startDate ? statsStartDate.format("YYYY-MM-DD") : startDate,
+                endDate: !endDate ? statsEndDate.format("YYYY-MM-DD") : endDate,
                 offset: new Date().getTimezoneOffset(),
             })
             .then(
@@ -150,8 +150,8 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
     onChangeDateRangeHandler: RangePickerProps["onChange"] = (_, dateStrings) => {
         this.setState({ loadedStats: false });
         const [startDateUTC, endDateUTC] = [
-            moment(dateStrings[0]).startOf("day").utc().toISOString(),
-            moment(dateStrings[1]).endOf("day").utc().toISOString(),
+            moment(dateStrings[0]).startOf("day").format("YYYY-MM-DD"),
+            moment(dateStrings[1]).endOf("day").format("YYYY-MM-DD"),
         ];
         this.getProjectStatsAndUpdateDates(startDateUTC, endDateUTC);
     };
@@ -205,8 +205,8 @@ export class ProjectDashboardPage extends Component<RouteComponentProps<RoutePar
                                     processingTime={processingTime}
                                     stats={projectStats}
                                     loadedStats={loadedStats}
-                                    startDate={statsStartDate.local().format("ddd, DD MMM")}
-                                    endDate={statsEndDate.local().format("ddd, DD MMM")}
+                                    startDate={statsStartDate.format("ddd, DD MMM")}
+                                    endDate={statsEndDate.format("ddd, DD MMM")}
                                 />
                                 <ChartsSection stats={projectStats.slice().reverse()} loadedStats={loadedStats} />
                                 <StatsTableSection

--- a/estela-web/src/services/api/generated-api/apis/ApiApi.ts
+++ b/estela-web/src/services/api/generated-api/apis/ApiApi.ts
@@ -438,15 +438,6 @@ export interface ApiProjectsUsageRequest {
     endDate?: string;
 }
 
-export interface ApiStatsJobsRequest {
-    pid: string;
-    startDate: string;
-    endDate: string;
-    spider: number;
-    page?: number;
-    pageSize?: number;
-}
-
 export interface ApiStatsListRequest {
     pid: string;
     startDate: string;
@@ -461,9 +452,9 @@ export interface ApiStatsSpiderJobsRequest {
     sid: string;
     startDate: string;
     endDate: string;
-    spider: number;
     page?: number;
     pageSize?: number;
+    offset?: number;
 }
 
 export interface ApiStatsSpiderListRequest {
@@ -482,6 +473,7 @@ export interface ApiStatsSpidersRequest {
     endDate: string;
     page?: number;
     pageSize?: number;
+    offset?: number;
 }
 
 /**
@@ -2609,71 +2601,6 @@ export class ApiApi extends runtime.BaseAPI {
     }
 
     /**
-     * Retrieve all the jobs of a spider executed in a range of dates.
-     */
-    async apiStatsJobsRaw(requestParameters: ApiStatsJobsRequest): Promise<runtime.ApiResponse<JobsPagination>> {
-        if (requestParameters.pid === null || requestParameters.pid === undefined) {
-            throw new runtime.RequiredError('pid','Required parameter requestParameters.pid was null or undefined when calling apiStatsJobs.');
-        }
-
-        if (requestParameters.startDate === null || requestParameters.startDate === undefined) {
-            throw new runtime.RequiredError('startDate','Required parameter requestParameters.startDate was null or undefined when calling apiStatsJobs.');
-        }
-
-        if (requestParameters.endDate === null || requestParameters.endDate === undefined) {
-            throw new runtime.RequiredError('endDate','Required parameter requestParameters.endDate was null or undefined when calling apiStatsJobs.');
-        }
-
-        if (requestParameters.spider === null || requestParameters.spider === undefined) {
-            throw new runtime.RequiredError('spider','Required parameter requestParameters.spider was null or undefined when calling apiStatsJobs.');
-        }
-
-        const queryParameters: any = {};
-
-        if (requestParameters.page !== undefined) {
-            queryParameters['page'] = requestParameters.page;
-        }
-
-        if (requestParameters.pageSize !== undefined) {
-            queryParameters['page_size'] = requestParameters.pageSize;
-        }
-
-        if (requestParameters.startDate !== undefined) {
-            queryParameters['start_date'] = requestParameters.startDate;
-        }
-
-        if (requestParameters.endDate !== undefined) {
-            queryParameters['end_date'] = requestParameters.endDate;
-        }
-
-        if (requestParameters.spider !== undefined) {
-            queryParameters['spider'] = requestParameters.spider;
-        }
-
-        const headerParameters: runtime.HTTPHeaders = {};
-
-        if (this.configuration && (this.configuration.username !== undefined || this.configuration.password !== undefined)) {
-            headerParameters["Authorization"] = "Basic " + btoa(this.configuration.username + ":" + this.configuration.password);
-        }
-        const response = await this.request({
-            path: `/api/stats/{pid}/jobs`.replace(`{${"pid"}}`, encodeURIComponent(String(requestParameters.pid))),
-            method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
-        });
-
-        return new runtime.JSONApiResponse(response, (jsonValue) => JobsPaginationFromJSON(jsonValue));
-    }
-
-    /**
-     * Retrieve all the jobs of a spider executed in a range of dates.
-     */
-    async apiStatsJobs(requestParameters: ApiStatsJobsRequest): Promise<JobsPagination> {
-        const response = await this.apiStatsJobsRaw(requestParameters);
-        return await response.value();
-    }
-
-    /**
      * Retrieve stats of all jobs in a range of time, dates must have the format YYYY-mm-dd.
      */
     async apiStatsListRaw(requestParameters: ApiStatsListRequest): Promise<runtime.ApiResponse<Array<ProjectStats>>> {
@@ -2754,10 +2681,6 @@ export class ApiApi extends runtime.BaseAPI {
             throw new runtime.RequiredError('endDate','Required parameter requestParameters.endDate was null or undefined when calling apiStatsSpiderJobs.');
         }
 
-        if (requestParameters.spider === null || requestParameters.spider === undefined) {
-            throw new runtime.RequiredError('spider','Required parameter requestParameters.spider was null or undefined when calling apiStatsSpiderJobs.');
-        }
-
         const queryParameters: any = {};
 
         if (requestParameters.page !== undefined) {
@@ -2776,8 +2699,8 @@ export class ApiApi extends runtime.BaseAPI {
             queryParameters['end_date'] = requestParameters.endDate;
         }
 
-        if (requestParameters.spider !== undefined) {
-            queryParameters['spider'] = requestParameters.spider;
+        if (requestParameters.offset !== undefined) {
+            queryParameters['offset'] = requestParameters.offset;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -2900,6 +2823,10 @@ export class ApiApi extends runtime.BaseAPI {
 
         if (requestParameters.endDate !== undefined) {
             queryParameters['end_date'] = requestParameters.endDate;
+        }
+
+        if (requestParameters.offset !== undefined) {
+            queryParameters['offset'] = requestParameters.offset;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/estela-web/src/utils.ts
+++ b/estela-web/src/utils.ts
@@ -5,6 +5,14 @@ export interface BytesMetric {
     type: string;
 }
 
+export interface Duration {
+    days: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+    milliseconds: number;
+}
+
 function completeDateInfo(data: number): string {
     if (data < 10) {
         return `0${data}`;
@@ -25,30 +33,71 @@ export function convertDateToString(date: Date | undefined): string {
     return "";
 }
 
-export function formatSecondsToHHMMSS(seconds: number): string {
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const remainingSeconds = Math.round(seconds) % 60;
-    const formattedTime = [
-        hours.toString().padStart(2, "0"),
-        minutes.toString().padStart(2, "0"),
-        remainingSeconds.toString().padStart(2, "0"),
-    ].join(":");
-    return formattedTime;
-}
-
 export function setValArr({ arr, val, index }: { arr: number[]; val: number; index: number }): number[] {
     arr.fill(val, index, index + 1);
     return arr;
 }
 
-export function parseDurationToSeconds(durationString: string | undefined): number {
-    if (durationString) {
-        const [hours, minutes, seconds] = durationString.split(":").map(Number);
-        const totalSeconds = hours * 3600 + minutes * 60 + seconds;
-        return totalSeconds;
+export function parseDuration(duration: string | undefined): Duration {
+    if (duration && duration !== "undefined") {
+        const durationRegex = /(?:(\d+) days?,\s*)?(\d{1,2}):(\d{1,2}):(\d{1,2})(?:\.(\d+))?/;
+        const matches = duration.match(durationRegex);
+        if (!matches) {
+            return { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
+        }
+        const [, daysStr, hoursStr, minutesStr, secondsStr, millisecondsStr] = matches;
+        const days = parseInt(daysStr || "0", 10);
+        const hours = parseInt(hoursStr, 10);
+        const minutes = parseInt(minutesStr, 10);
+        const seconds = parseInt(secondsStr, 10);
+        const milliseconds = parseInt(millisecondsStr || "0", 10);
+        return {
+            days,
+            hours,
+            minutes,
+            seconds,
+            milliseconds,
+        };
     }
-    return 0;
+    return { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
+}
+
+export function durationToString(duration: Duration): string {
+    let str = duration.days > 0 ? `${duration.days} days, ` : "";
+    str += duration.hours > 0 ? `${duration.hours}` : "0";
+    str += duration.minutes > 0 ? `:${duration.minutes.toString().padStart(2, "0")}` : ":00";
+    str += duration.seconds > 0 ? `:${duration.seconds.toString().padStart(2, "0")}` : ":00";
+    if (duration.milliseconds > 0) str += `.${duration.milliseconds.toString().padStart(3, "0")}`;
+    return str;
+}
+
+export function durationToSeconds(duration: Duration): number {
+    const { days, hours, minutes, seconds, milliseconds } = duration;
+    return days * 24 * 60 * 60 + hours * 60 * 60 + minutes * 60 + seconds + milliseconds / 1000;
+}
+
+export function secondsToDuration(seconds: number): Duration {
+    const milliseconds = seconds * 1000;
+
+    const days = Math.floor(milliseconds / 86400000);
+    const remainingMilliseconds = milliseconds % 86400000;
+
+    const hours = Math.floor(remainingMilliseconds / 3600000);
+    const remainingMillisecondsAfterHours = remainingMilliseconds % 3600000;
+
+    const minutes = Math.floor(remainingMillisecondsAfterHours / 60000);
+    const remainingMillisecondsAfterMinutes = remainingMillisecondsAfterHours % 60000;
+
+    const secondsInDuration = Math.floor(remainingMillisecondsAfterMinutes / 1000);
+    const millisecondsInDuration = remainingMillisecondsAfterMinutes % 1000;
+
+    return {
+        days,
+        hours,
+        minutes,
+        seconds: secondsInDuration,
+        milliseconds: millisecondsInDuration,
+    };
 }
 
 export function sumArr(arr: number[]): number {


### PR DESCRIPTION
# Description

Some issues appeared in bitmaker cloud staging during black-box testing, see the [thread discussion](https://bitmakerla.slack.com/archives/C04TQNZE97Y/p1689971355166469):
- Query issues some details show more spiders than there are in the project.
- Change delay time to format HH:MM:SS.
- Processing time appear as NaN sometimes, instead it should be 0.
- Some jobs are not considered in the date detail.

Tasks:
- Solve the issues and testing.
- Deploy on staging and see results.

Completion Criteria:
- Issues are solved..

# Issue

* https://tasks.bitmaker.dev/issues/3570.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [x] New and existing tests pass locally with my changes.
- [x] If this change is a core feature, I have added thorough tests.
- [x] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [x] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
