### PR TITLE
BITMAKER-3629 : Fix duration parsing.

### DIFF
--- a/estela-web/src/components/Stats/StatsDateModalContent.tsx
+++ b/estela-web/src/components/Stats/StatsDateModalContent.tsx
@@ -165,10 +165,11 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
     rightSidedStatsSection(): JSX.Element {
         const { pid } = this.props;
         const { activeSpider, overviewTabSelected, activeJob, jobs } = this.state;
-
         const spiderBandwidth = formatBytes(
             jobs.results.reduce((acc, curr) => acc + (curr.totalResponseBytes ?? 0), 0),
         );
+        const activeJobLifeSpan = activeJob.stats?.runtime ? activeJob.stats.runtime.toString() : "0:00:00";
+        const formattedActiveJobLifeSpan = durationToString(parseDuration(activeJobLifeSpan));
         const spiderProcessingTime = durationToString(
             secondsToDuration(
                 Math.round(
@@ -208,10 +209,10 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
                             <div className="flex items-center gap-x-5 py-5">
                                 <div className="w-3/12 rounded-lg border-2 border-estela-states-green-full p-3 bg-estela-blue-low">
                                     <p className="text-center text-estela-states-green-full text-sm font-bold">
-                                        {activeJob.lifespan || "0:00:00"}
+                                        {formattedActiveJobLifeSpan}
                                     </p>
                                     <p title="Duration" className="text-center text-estela-states-green-full text-sm">
-                                        Dur.
+                                        Lifespan
                                     </p>
                                 </div>
                                 <div className="w-9/12">
@@ -286,7 +287,7 @@ export class StatsDateModalContent extends Component<StatsDateModalContentProps,
                                         {spiderProcessingTime}
                                     </p>
                                     <p title="Duration" className="text-center text-estela-blue-full text-sm">
-                                        Dur.
+                                        Lifespan
                                     </p>
                                 </div>
                                 <div className="w-9/12">

--- a/estela-web/src/pages/JobDetailPage/index.tsx
+++ b/estela-web/src/pages/JobDetailPage/index.tsx
@@ -26,7 +26,7 @@ import { Link, RouteComponentProps } from "react-router-dom";
 import "./styles.scss";
 import history from "../../history";
 import { ApiService } from "../../services";
-import { BytesMetric, durationToString, formatBytes, secondsToDuration } from "../../utils";
+import { BytesMetric, parseDuration, durationToString, formatBytes } from "../../utils";
 import Copy from "../../assets/icons/copy.svg";
 import Pause from "../../assets/icons/pause.svg";
 import Add from "../../assets/icons/add.svg";
@@ -291,9 +291,7 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
                 const args = response.args || [];
                 const envVars = response.envVars || [];
                 const tags = response.tags || [];
-                const lifeSpanArr: string[] = String(response.lifespan ?? 0).split(":");
-                const lifespan: number =
-                    lifeSpanArr.length !== 3 ? 0 : +lifeSpanArr[0] * 3600 + +lifeSpanArr[1] * 60 + +lifeSpanArr[2];
+                const lifespan = parseDuration(response.lifespan);
                 this.setState({
                     name: response.name,
                     lifespan: lifespan,
@@ -946,7 +944,7 @@ export class JobDetailPage extends Component<RouteComponentProps<RouteParams>, J
                         <Row className="grid grid-cols-1 py-1 px-2 mt-3">
                             <Col>
                                 <Text className="font-bold text-estela-black-full text-lg">
-                                    {durationToString(secondsToDuration(lifespan || 0))}
+                                    {durationToString(lifespan || 0)}
                                 </Text>
                             </Col>
                             <Col>

--- a/estela-web/src/utils.ts
+++ b/estela-web/src/utils.ts
@@ -39,7 +39,7 @@ export function setValArr({ arr, val, index }: { arr: number[]; val: number; ind
 
 export function parseDuration(duration: string | undefined): Duration {
     if (duration && duration !== "undefined") {
-        const durationRegex = /(?:(\d+) days?,\s*)?(\d{1,2}):(\d{1,2}):(\d{1,2}?\.*(\d*))?/;
+        const durationRegex = /(?:(\d+) \s*)?(\d{1,2}):(\d{1,2}):(\d{1,2}?\.*(\d*))?/;
 
         const matches = duration.match(durationRegex);
         if (!matches) {

--- a/estela-web/src/utils.ts
+++ b/estela-web/src/utils.ts
@@ -10,7 +10,6 @@ export interface Duration {
     hours: number;
     minutes: number;
     seconds: number;
-    milliseconds: number;
 }
 
 function completeDateInfo(data: number): string {
@@ -40,26 +39,24 @@ export function setValArr({ arr, val, index }: { arr: number[]; val: number; ind
 
 export function parseDuration(duration: string | undefined): Duration {
     if (duration && duration !== "undefined") {
-        const durationRegex = /(?:(\d+) days?,\s*)?(\d{1,2}):(\d{1,2}):(\d{1,2})(?:\.(\d+))?/;
+        const durationRegex = /(?:(\d+) days?,\s*)?(\d{1,2}):(\d{1,2}):(\d{1,2}?\.(\d+))?/;
         const matches = duration.match(durationRegex);
         if (!matches) {
-            return { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
+            return { days: 0, hours: 0, minutes: 0, seconds: 0 };
         }
-        const [, daysStr, hoursStr, minutesStr, secondsStr, millisecondsStr] = matches;
+        const [, daysStr, hoursStr, minutesStr, secondsStr] = matches;
         const days = parseInt(daysStr || "0", 10);
         const hours = parseInt(hoursStr, 10);
         const minutes = parseInt(minutesStr, 10);
         const seconds = parseInt(secondsStr, 10);
-        const milliseconds = parseInt(millisecondsStr || "0", 10);
         return {
             days,
             hours,
             minutes,
             seconds,
-            milliseconds,
         };
     }
-    return { days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 };
+    return { days: 0, hours: 0, minutes: 0, seconds: 0 };
 }
 
 export function durationToString(duration: Duration): string {
@@ -67,36 +64,29 @@ export function durationToString(duration: Duration): string {
     str += duration.hours > 0 ? `${duration.hours}` : "0";
     str += duration.minutes > 0 ? `:${duration.minutes.toString().padStart(2, "0")}` : ":00";
     str += duration.seconds > 0 ? `:${duration.seconds.toString().padStart(2, "0")}` : ":00";
-    if (duration.milliseconds > 0) str += `.${duration.milliseconds.toString().padStart(3, "0")}`;
     return str;
 }
 
 export function durationToSeconds(duration: Duration): number {
-    const { days, hours, minutes, seconds, milliseconds } = duration;
-    return days * 24 * 60 * 60 + hours * 60 * 60 + minutes * 60 + seconds + milliseconds / 1000;
+    const { days, hours, minutes, seconds } = duration;
+    return days * 24 * 60 * 60 + hours * 60 * 60 + minutes * 60 + seconds;
 }
 
 export function secondsToDuration(seconds: number): Duration {
-    const milliseconds = seconds * 1000;
+    const days = Math.floor(seconds / 86400);
+    const remainingSeconds = seconds % 86400;
 
-    const days = Math.floor(milliseconds / 86400000);
-    const remainingMilliseconds = milliseconds % 86400000;
+    const hours = Math.floor(remainingSeconds / 3600);
+    const remainingSecondsAfterHours = remainingSeconds % 3600;
 
-    const hours = Math.floor(remainingMilliseconds / 3600000);
-    const remainingMillisecondsAfterHours = remainingMilliseconds % 3600000;
-
-    const minutes = Math.floor(remainingMillisecondsAfterHours / 60000);
-    const remainingMillisecondsAfterMinutes = remainingMillisecondsAfterHours % 60000;
-
-    const secondsInDuration = Math.floor(remainingMillisecondsAfterMinutes / 1000);
-    const millisecondsInDuration = remainingMillisecondsAfterMinutes % 1000;
+    const minutes = Math.floor(remainingSecondsAfterHours / 60);
+    const remainingSecondsAfterMinutes = remainingSecondsAfterHours % 60;
 
     return {
         days,
         hours,
         minutes,
-        seconds: secondsInDuration,
-        milliseconds: millisecondsInDuration,
+        seconds: Math.floor(remainingSecondsAfterMinutes),
     };
 }
 

--- a/estela-web/src/utils.ts
+++ b/estela-web/src/utils.ts
@@ -39,7 +39,8 @@ export function setValArr({ arr, val, index }: { arr: number[]; val: number; ind
 
 export function parseDuration(duration: string | undefined): Duration {
     if (duration && duration !== "undefined") {
-        const durationRegex = /(?:(\d+) days?,\s*)?(\d{1,2}):(\d{1,2}):(\d{1,2}?\.(\d+))?/;
+        const durationRegex = /(?:(\d+) days?,\s*)?(\d{1,2}):(\d{1,2}):(\d{1,2}?\.*(\d*))?/;
+
         const matches = duration.match(durationRegex);
         if (!matches) {
             return { days: 0, hours: 0, minutes: 0, seconds: 0 };


### PR DESCRIPTION
# Description

- [x] Fix duration parsing

Our current method of parsing the duration data received from the backend is incorrect. The durations are provided in the following format: "HH:MM:SS.SSSSSS". Here are a couple of examples:

"00:00:10.729321"
"00:01:13.422526"
In this format, the first example represents a duration of 10.729321 seconds.

Previously, we erroneously interpreted the last six digits (for instance, 729321 in the first example) as milliseconds. This interpretation is not accurate as these six digits represent fractional seconds and not milliseconds. We need to adjust our parsing to reflect this understanding.


# Issue

* _Github Issue ID_.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [ ] New and existing tests pass locally with my changes.
- [ ] If this change is a core feature, I have added thorough tests.
- [ ] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [ ] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
