### PR TITLE
BITMAKER-3606 Feature environments: Automatic workflow for deploying estela-docs on PRs events

### DIFF
--- a/.github/workflows/deploy-preview-docs.yml
+++ b/.github/workflows/deploy-preview-docs.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - docs/**
 
+env:
+  BUCKET_REGION: us-west-2
+
 jobs:
   build:
     name: Build preview docs
@@ -12,9 +15,67 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Set-up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           working-directory: "./docs/"
-      - name:
+
+      - name: Install redoc-cli
+        run: |
+          yarn global add redoc-cli@0.13.16
+          echo "$(yarn global bin)" >> $GITHUB_PATH
+
+      - name: Build Swagger Documentation
+        run: redoc-cli build ./estela-api/docs/api.yaml -t ./docs/assets/swagger-template.hbs --options.hideDownloadButton -o ./docs/estela/api/endpoints.html
+
+      - name: Build Site
+        run: |
+          cd ./docs
+          bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      - name: Set Environment Variables
+        run: |
+          export _BUCKET_NAME=$(echo estela-docs-${{ github.head_ref }}.la | tr '[:upper:]' '[:lower:]')
+          echo "BUCKET_NAME=$_BUCKET_NAME" >> $GITHUB_ENV
+          echo "{
+            \"Version\": \"2012-10-17\",
+            \"Statement\": [
+              {
+                \"Sid\": \"PublicReadGetObject\",
+                \"Effect\": \"Allow\",
+                \"Principal\": \"*\",
+                \"Action\": \"s3:GetObject\",
+                \"Resource\": \"arn:aws:s3:::$_BUCKET_NAME/*\"
+              }
+            ]
+          }" > bucket_policy.json
+
+      - name: Create New S3 Bucket
+        run: |
+          if ! aws s3api head-bucket --bucket $BUCKET_NAME 2>/dev/null; then \
+            aws s3 mb s3://$BUCKET_NAME; \
+            aws s3 website s3://$BUCKET_NAME --index-document ./_site/index.html; \
+            aws s3api put-public-access-block --bucket $BUCKET_NAME --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"; \
+            aws s3api put-bucket-policy --bucket $BUCKET_NAME --policy file://bucket_policy.json; \
+          fi
+
+      - name: Deploy to S3 Bucket
+        run: aws s3 sync ./_site/ s3://$BUCKET_NAME --delete
+
+      - name: Comment Website Direction
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          recreate: true
+          message: |
+            [`${{ github.sha }}`] Check out the preview [here](http://${{ env.BUCKET_NAME }}.s3-website-${{ env.BUCKET_REGION }}.amazonaws.com) :point_left:

--- a/.github/workflows/deploy-preview-docs.yml
+++ b/.github/workflows/deploy-preview-docs.yml
@@ -1,0 +1,20 @@
+name: Build and Deploy preview for the Docs
+on:
+  pull_request:
+    paths:
+      - docs/**
+
+jobs:
+  build:
+    name: Build preview docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set-up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          working-directory: "./docs/"
+      - name:

--- a/.github/workflows/pr-delete-preview-docs.yml
+++ b/.github/workflows/pr-delete-preview-docs.yml
@@ -1,0 +1,24 @@
+name: Delete Closed Pull-Request Docs preview
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete_bucket:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Environment Variables
+        run: |
+          echo "BUCKET_NAME=$(echo estela-docs-${{ github.head_ref }}.la | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      - name: Delete S3 Bucket
+        run: aws s3 rb s3://$BUCKET_NAME --force

--- a/.github/workflows/pr-preview-docs.yml
+++ b/.github/workflows/pr-preview-docs.yml
@@ -1,11 +1,8 @@
-name: Build and Deploy preview for the Docs
+name: Build and Deploy Docs preview
 on:
   pull_request:
     paths:
       - docs/**
-
-env:
-  BUCKET_REGION: us-west-2
 
 jobs:
   build:
@@ -71,11 +68,11 @@ jobs:
           fi
 
       - name: Deploy to S3 Bucket
-        run: aws s3 sync ./_site/ s3://$BUCKET_NAME --delete
+        run: aws s3 sync ./_site/ s3://$BUCKET_NAME/docs/ --delete
 
       - name: Comment Website Direction
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true
           message: |
-            [`${{ github.sha }}`] Check out the preview [here](http://${{ env.BUCKET_NAME }}.s3-website-${{ env.BUCKET_REGION }}.amazonaws.com) :point_left:
+            [`${{ github.sha }}`] Check out the docs preview [here](http://${{ env.BUCKET_NAME }}.s3-website-${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com) :point_left:


### PR DESCRIPTION
# Description

Develop a github action that automatically deploys estela docs when a contributor does a PR on modifying estela docs.
Tasks:
- Develop the workflow with github actions.
- Show a preview of the new docs in the PR.

Completion criteria:
- Modify some part of the documentation, make a PR and show a preview.

# Issue

* https://tasks.bitmaker.dev/issues/3606.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [ ] New and existing tests pass locally with my changes.
- [ ] If this change is a core feature, I have added thorough tests.
- [ ] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [ ] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
