### PR TITLE
BITMAKER-3721: estela-web. Fix text casing when viewing stuff as admin

### DIFF
--- a/estela-web/src/pages/ProjectListPage/index.tsx
+++ b/estela-web/src/pages/ProjectListPage/index.tsx
@@ -121,7 +121,7 @@ export class ProjectListPage extends Component<unknown, ProjectsPageState> {
                 pid: project.pid,
                 role:
                     project.users?.find((user) => user.user?.username === AuthService.getUserUsername())?.permission ||
-                    "Admin",
+                    "ADMIN",
                 key: id,
             };
         });
@@ -192,7 +192,7 @@ export class ProjectListPage extends Component<unknown, ProjectsPageState> {
                 framework: project.framework,
                 role:
                     project.users?.find((user) => user.user?.username === AuthService.getUserUsername())?.permission ||
-                    "Admin",
+                    "ADMIN",
                 key: id,
             };
         });


### PR DESCRIPTION
# Description

If we are an admin and we go the project list, we will appear as Admin for all projects and the text is capitalized instead of all in caps.

# Issue

https://tasks.bitmaker.dev/issues/3721

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] My code follows the style guidelines of this project.
- [X] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [X] New and existing tests pass locally with my changes.
- [X] If this change is a core feature, I have added thorough tests.
- [X] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [X] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
