### PR TITLE
BITMAKER-2953: Invalidate registration confirmation token after activation

### DIFF
--- a/estela-api/api/views/auth.py
+++ b/estela-api/api/views/auth.py
@@ -77,16 +77,19 @@ class AuthAPIViewSet(viewsets.GenericViewSet):
     def register(self, request, *args, **kwargs):
         if not settings.REGISTER == "True":
             raise MethodNotAllowed({"error": "This action is disabled"})
+
         serializer: AuthTokenSerializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
         user.is_active = False
         user.save()
         update_last_login(None, user)
+
         try:
             send_verification_email(user, request)
         except Exception:
             raise EmailServiceError({"error": errors.ERROR_SENDING_VERIFICATION_EMAIL})
+
         token, _ = Token.objects.get_or_create(user=user)
         return Response(TokenSerializer(token).data)
 
@@ -95,30 +98,36 @@ class AuthAPIViewSet(viewsets.GenericViewSet):
         token = request.query_params.get("token", "")
         user_id_base64 = request.query_params.get("pair", "")
         user_id = force_text(urlsafe_base64_decode(user_id_base64))
+
         user = User.objects.filter(pk=user_id)
         if not user:
             return redirect(
                 settings.CORS_ORIGIN_WHITELIST[0], {"error": "User does not exist."}
             )
+
         user = user.get()
-        if account_reset_token.check_token(user, token):
-            if not user.is_active:
-                user.is_active = True
-                user.save()
-                mail_subject = "New User Registered."
-                message = render_to_string(
-                    "alert_new_user.html",
-                    {
-                        "user": user,
-                    },
-                )
-                email = EmailMessage(
-                    mail_subject,
-                    message,
-                    from_email=settings.VERIFICATION_EMAIL,
-                    to=settings.EMAILS_TO_ALERT.split(","),
-                )
-                email.send()
+        if user.is_active:
+            return redirect(
+                "".join([settings.CORS_ORIGIN_WHITELIST[0], "/activatedAccount"]),
+                {"message": "Account already activated!"},
+            )
+        elif account_reset_token.check_token(user, token):
+            user.is_active = True
+            user.save()
+            mail_subject = "New User Registered."
+            message = render_to_string(
+                "alert_new_user.html",
+                {
+                    "user": user,
+                },
+            )
+            email = EmailMessage(
+                mail_subject,
+                message,
+                from_email=settings.VERIFICATION_EMAIL,
+                to=settings.EMAILS_TO_ALERT.split(","),
+            )
+            email.send()
             return redirect(
                 "".join([settings.CORS_ORIGIN_WHITELIST[0], "/activatedAccount"]),
                 {
@@ -126,15 +135,6 @@ class AuthAPIViewSet(viewsets.GenericViewSet):
                 },
             )
         else:
-            if user.is_active:
-                return redirect(
-                    "".join(
-                        [settings.CORS_ORIGIN_WHITELIST[0],
-                         "/activatedAccount"]
-                    ),
-                    {"message": "Account already activated!"},
-                )
-
             self.retry_send_verification_email(user, request)
             return redirect(
                 settings.CORS_ORIGIN_WHITELIST[0],

--- a/estela-api/config/settings/base.py
+++ b/estela-api/config/settings/base.py
@@ -61,7 +61,7 @@ env = environ.Env(
     EMAILS_TO_ALERT=(str, "dummy"),
     REGISTER=(str, "dummy"),
     EMAIL_HOST=(str, "dummy"),
-    EMAIL_PORT=(str, "dummy"),
+    EMAIL_PORT=(int, "dummy"),
     VERIFICATION_EMAIL=(str, "dummy"),
 )
 environ.Env.read_env(env_file=".env")


### PR DESCRIPTION
# Description

We should not allow multiple confirmations of an email registration.
We probably need to verify if the user email is already verified here: https://github.com/bitmakerla/estela/blob/1a1789ffdf6d2e82bf3b297b5786f6cc58090567/estela-api/api/views/auth.py#L94.

Completion criteria:
- Users should only be able to confirm their emails once after registration. Check if their email is already validated before sending more registration confirmation emails.

# Issue

https://tasks.bitmaker.dev/issues/2953

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] My code follows the style guidelines of this project.
- [X] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [X] New and existing tests pass locally with my changes.
- [X] If this change is a core feature, I have added thorough tests.
- [X] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [X] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
