### PR TITLE
feat: Allow superadmins to transfer project ownership

### DIFF
--- a/estela-api/api/serializers/auth.py
+++ b/estela-api/api/serializers/auth.py
@@ -73,7 +73,8 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = User
-        fields = ["username", "email", "password"]
+        fields = ["username", "email", "password", "is_superuser"]
+        read_only_fields = ["is_superuser"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/estela-api/api/serializers/project.py
+++ b/estela-api/api/serializers/project.py
@@ -121,6 +121,7 @@ class ProjectUpdateSerializer(serializers.ModelSerializer):
         ("ADMIN", "Admin"),
         ("DEVELOPER", "Developer"),
         ("VIEWER", "Viewer"),
+        ("OWNER", "Owner")
     ]
     pid = serializers.UUIDField(
         read_only=True, help_text="A UUID identifying this project."

--- a/estela-api/api/views/project.py
+++ b/estela-api/api/views/project.py
@@ -151,6 +151,14 @@ class ProjectViewSet(BaseViewSet, ActionHandlerMixin, viewsets.ModelViewSet):
                 instance.users.remove(affected_user)
                 description = f"removed user {user_email}."
             elif action == "update":
+                if permission == Permission.OWNER_PERMISSION:
+                    old_owner = instance.users.filter(
+                        permission__permission=Permission.OWNER_PERMISSION
+                    ).get()
+                    instance.users.remove(old_owner)
+                    instance.users.add(
+                        old_owner, through_defaults={"permission": Permission.ADMIN_PERMISSION}
+                    )
                 instance.users.remove(affected_user)
                 instance.users.add(
                     affected_user, through_defaults={"permission": permission}

--- a/estela-api/api/views/project.py
+++ b/estela-api/api/views/project.py
@@ -152,12 +152,17 @@ class ProjectViewSet(BaseViewSet, ActionHandlerMixin, viewsets.ModelViewSet):
                 description = f"removed user {user_email}."
             elif action == "update":
                 if permission == Permission.OWNER_PERMISSION:
+                    if not is_superuser:
+                        raise PermissionDenied(
+                            {"permission": "You do not have permission to do this."}
+                        )
                     old_owner = instance.users.filter(
                         permission__permission=Permission.OWNER_PERMISSION
                     ).get()
                     instance.users.remove(old_owner)
                     instance.users.add(
-                        old_owner, through_defaults={"permission": Permission.ADMIN_PERMISSION}
+                        old_owner,
+                        through_defaults={"permission": Permission.ADMIN_PERMISSION},
                     )
                 instance.users.remove(affected_user)
                 instance.users.add(

--- a/estela-api/docs/api.yaml
+++ b/estela-api/docs/api.yaml
@@ -1709,6 +1709,12 @@ definitions:
         title: Password
         type: string
         minLength: 1
+      is_superuser:
+        title: Superuser status
+        description: Designates that this user has all permissions without explicitly
+          assigning them.
+        type: boolean
+        readOnly: true
   User:
     required:
       - username
@@ -1966,6 +1972,7 @@ definitions:
           - ADMIN
           - DEVELOPER
           - VIEWER
+          - OWNER
       data_status:
         title: Data status
         description: New data status.

--- a/estela-web/src/services/api/generated-api/models/ProjectUpdate.ts
+++ b/estela-web/src/services/api/generated-api/models/ProjectUpdate.ts
@@ -114,7 +114,8 @@ export enum ProjectUpdateFrameworkEnum {
 export enum ProjectUpdatePermissionEnum {
     Admin = 'ADMIN',
     Developer = 'DEVELOPER',
-    Viewer = 'VIEWER'
+    Viewer = 'VIEWER',
+    Owner = 'OWNER'
 }/**
 * @export
 * @enum {string}

--- a/estela-web/src/services/api/generated-api/models/UserProfile.ts
+++ b/estela-web/src/services/api/generated-api/models/UserProfile.ts
@@ -37,6 +37,12 @@ export interface UserProfile {
      * @memberof UserProfile
      */
     password: string;
+    /**
+     * Designates that this user has all permissions without explicitly assigning them.
+     * @type {boolean}
+     * @memberof UserProfile
+     */
+    readonly isSuperuser?: boolean;
 }
 
 export function UserProfileFromJSON(json: any): UserProfile {
@@ -52,6 +58,7 @@ export function UserProfileFromJSONTyped(json: any, ignoreDiscriminator: boolean
         'username': json['username'],
         'email': json['email'],
         'password': json['password'],
+        'isSuperuser': !exists(json, 'is_superuser') ? undefined : json['is_superuser'],
     };
 }
 

--- a/queueing/Dockerfile
+++ b/queueing/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM python:3.9-slim as builder
+FROM python:3.9-slim AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1


### PR DESCRIPTION
# Description

SuperAdmins should be able to change what user owns a project. When making this change, the previous owner should be set as an ADMIN because no project should have more than 1 owner.

Completion criteria:
- Allow superadmins to change the owner of a project.

# Issue

https://tasks.bitmaker.dev/issues/3750

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] My code follows the style guidelines of this project.
- [X] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [X] New and existing tests pass locally with my changes.
- [X] If this change is a core feature, I have added thorough tests.
- [X] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [X] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
