### PR TITLE
[change]estela-web: Show register page based on the REGISTER_PAGE_ENABLED variable

### DIFF
--- a/estela-web/.env.development.example
+++ b/estela-web/.env.development.example
@@ -1,1 +1,2 @@
 REACT_APP_API_BASE_URL=http://localhost:8000
+REGISTER_PAGE_ENABLED=true

--- a/estela-web/src/constants.ts
+++ b/estela-web/src/constants.ts
@@ -1,1 +1,2 @@
 export const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
+export const REGISTER_PAGE_ENABLED = process.env.REGISTER_PAGE_ENABLED === "true";

--- a/estela-web/src/pages/LoginPage/index.tsx
+++ b/estela-web/src/pages/LoginPage/index.tsx
@@ -9,6 +9,7 @@ import { ApiAuthLoginRequest, Token } from "../../services/api";
 import { handleInvalidDataError } from "../../utils";
 import { UserContext, UserContextProps } from "../../context";
 import { EstelaBanner } from "../../components";
+import { REGISTER_PAGE_ENABLED } from "../../constants";
 
 const { Content } = Layout;
 const { Text } = Typography;
@@ -105,14 +106,16 @@ export class LoginPage extends Component<unknown, LoginState> {
                         >
                             Log in
                         </Button>
-                        <Content className="text-center text-base m-5">
-                            <p>If you don&apos;t have an account. You can</p>
-                            <p>
-                                <Link className="text-estela text-base font-bold underline" to="/register">
-                                    register here
-                                </Link>
-                            </p>
-                        </Content>
+                        {REGISTER_PAGE_ENABLED && (
+                            <Content className="text-center text-base m-5">
+                                <p>If you don&apos;t have an account. You can</p>
+                                <p>
+                                    <Link className="text-estela text-base font-bold underline" to="/register">
+                                        register here
+                                    </Link>
+                                </p>
+                            </Content>
+                        )}
                     </Form>
                 </Content>
             </Content>

--- a/estela-web/src/routes/index.tsx
+++ b/estela-web/src/routes/index.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Switch, Route, Redirect } from "react-router-dom";
 
+import { REGISTER_PAGE_ENABLED } from "../constants";
+
 import { ActivatedAccountPage } from "../pages/ActivatedAccountPage";
 import { LoginPage } from "../pages/LoginPage";
 import { RegisterPage } from "../pages/RegisterPage";
@@ -34,10 +36,19 @@ export const MainRoutes: React.FC = () => {
                 <Redirect to="/login" />
             </Route>
 
-            <Route path={["/login", "/register", "/forgotPassword", "/resetPassword", "/activatedAccount"]} exact>
+            <Route
+                path={[
+                    "/login",
+                    REGISTER_PAGE_ENABLED ? "/register" : null,
+                    "/forgotPassword",
+                    "/resetPassword",
+                    "/activatedAccount",
+                ].filter(Boolean)}
+                exact
+            >
                 <AuthLayout>
                     <Route path="/login" component={LoginPage} exact />
-                    <Route path="/register" component={RegisterPage} exact />
+                    {REGISTER_PAGE_ENABLED && <Route path="/register" component={RegisterPage} exact />}
                     <Route path="/forgotPassword" component={ForgotPasswordPage} exact />
                     <Route path="/resetPassword" component={ResetPasswordPage} exact />
                     <Route path="/activatedAccount" component={ActivatedAccountPage} exact />


### PR DESCRIPTION
# Description

We can activate or deactivate the frontend Register views based on an environment variable.

# Issue

* [https://tasks.bitmaker.dev/issues/3858](https://tasks.bitmaker.dev/issues/3858)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [x] New and existing tests pass locally with my changes.
- [x] If this change is a core feature, I have added thorough tests.
- [x] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/).
- [x] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
