### PR TITLE
(fix)API: Correctly pass scheduled job proxy env vars when launching jobs

### DIFF
--- a/estela-api/api/utils.py
+++ b/estela-api/api/utils.py
@@ -1,12 +1,12 @@
 from datetime import timedelta
 
-import redis
 from django.conf import settings
+import redis
 
 from api import errors
 from api.exceptions import DataBaseError
 from config.job_manager import spiderdata_db_client
-from core.models import SpiderJobEnvVar, ProxyProvider
+from core.models import SpiderJobEnvVar
 
 
 def update_env_vars(instance, env_vars, level="project", delete=True):
@@ -75,8 +75,7 @@ def delete_stats_from_redis(job):
         pass
 
 
-def get_proxy_provider_envs(proxy_id):
-    proxy_provider = ProxyProvider.objects.get(pk=proxy_id)
+def get_proxy_provider_envs(proxy_provider):
     proxy_attrs = [
         "username",
         "password",


### PR DESCRIPTION
# Description

Fix scheduled jobs not passing proxy env vars correctly to jobs

# Issue

* [Issue ID](https://tasks.bitmaker.dev/issues/4178)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [ ] New and existing tests pass locally with my changes.
- [ ] If this change is a core feature, I have added thorough tests.
- [ ] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/).
- [ ] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
