### PR TITLE
fix: handle empty collections in download endpoint

### DIFF
--- a/estela-api/api/views/job_data.py
+++ b/estela-api/api/views/job_data.py
@@ -190,13 +190,14 @@ class JobDataViewSet(
                 kwargs["pid"], job_collection_name
             )
         else:
-            docs_limit = max(
-                1,
-                settings.MAX_WEB_DOWNLOAD_SIZE
-                // spiderdata_db_client.get_estimated_item_size(
+            try:
+                estimated_size = spiderdata_db_client.get_estimated_item_size(
                     kwargs["pid"], job_collection_name
-                ),
-            )
+                )
+                docs_limit = max(1, settings.MAX_WEB_DOWNLOAD_SIZE // estimated_size)
+            except:
+                docs_limit = settings.MAX_WEB_DOWNLOAD_SIZE
+            
             data = spiderdata_db_client.get_dataset_data(
                 kwargs["pid"], job_collection_name, docs_limit
             )


### PR DESCRIPTION
Previously, the download endpoint would throw a 500 error when attempting to download from empty collections due to division by zero when calculating docs_limit. Now gracefully handles this case by falling back to MAX_WEB_DOWNLOAD_SIZE when the collection is empty or size estimation fails.

🤖 Generated with [Claude Code](https://claude.ai/code)

# Description

_Please include a summary of the changes, relevant motivation and context_.

# Issue

* _Github Issue ID_.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [ ] New and existing tests pass locally with my changes.
- [ ] If this change is a core feature, I have added thorough tests.
- [ ] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/).
- [ ] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
