### PR TITLE
fix: handle empty collections in download endpoint

### DIFF
--- a/estela-api/api/views/job_data.py
+++ b/estela-api/api/views/job_data.py
@@ -190,13 +190,14 @@ class JobDataViewSet(
                 kwargs["pid"], job_collection_name
             )
         else:
-            docs_limit = max(
-                1,
-                settings.MAX_WEB_DOWNLOAD_SIZE
-                // spiderdata_db_client.get_estimated_item_size(
+            try:
+                estimated_size = spiderdata_db_client.get_estimated_item_size(
                     kwargs["pid"], job_collection_name
-                ),
-            )
+                )
+                docs_limit = max(1, settings.MAX_WEB_DOWNLOAD_SIZE // estimated_size)
+            except:
+                docs_limit = settings.MAX_WEB_DOWNLOAD_SIZE
+            
             data = spiderdata_db_client.get_dataset_data(
                 kwargs["pid"], job_collection_name, docs_limit
             )


### PR DESCRIPTION
Previously, the download endpoint would throw a 500 error when attempting to download from empty collections due to division by zero when calculating docs_limit. Now gracefully handles this case by falling back to MAX_WEB_DOWNLOAD_SIZE when the collection is empty or size estimation fails.

🤖 Generated with [Claude Code](https://claude.ai/code)
