### PR TITLE
Fix: Cronjob handling when spider is deleted

### DIFF
--- a/estela-api/api/serializers/cronjob.py
+++ b/estela-api/api/serializers/cronjob.py
@@ -159,11 +159,16 @@ class SpiderCronJobUpdateSerializer(
             description = f"changed the schedule of Sche-Job-{instance.cjid}."
 
         if "status" in validated_data:
-            instance.status = status
             if status == SpiderCronJob.ACTIVE_STATUS:
+                if instance.spider.deleted:
+                    raise serializers.ValidationError(
+                        {"error": "Cannot enable: spider no longer exists in the project."}
+                    )
+                instance.status = status
                 enable_cronjob(name)
                 description = f"enabled Sche-Job-{instance.cjid}."
             elif status == SpiderCronJob.DISABLED_STATUS:
+                instance.status = status
                 disable_cronjob(name)
                 description = f"disabled Sche-Job-{instance.cjid}."
 

--- a/estela-api/api/serializers/deploy.py
+++ b/estela-api/api/serializers/deploy.py
@@ -71,7 +71,9 @@ class DeployUpdateSerializer(serializers.ModelSerializer):
                 project.spiders.filter(name__in=spiders_names, deleted=True).update(
                     deleted=False
                 )
-                project.spiders.exclude(name__in=spiders_names).update(deleted=True)
+                for spider in project.spiders.exclude(name__in=spiders_names).filter(deleted=False):
+                    spider.deleted = True
+                    spider.save()
                 new_spiders = [
                     Spider(
                         name=spider_name,

--- a/estela-api/api/views/cronjob.py
+++ b/estela-api/api/views/cronjob.py
@@ -40,7 +40,6 @@ class SpiderCronJobViewSet(
         return self.model_class.objects.filter(
             spider__project__pid=self.kwargs["pid"],
             spider__sid=self.kwargs["sid"],
-            spider__deleted=False,
             deleted=False,
         )
 
@@ -154,6 +153,12 @@ class SpiderCronJobViewSet(
     def run_once(self, request, *args, **kwargs):
         partial = kwargs.pop("partial", False)
         instance = self.get_object()
+
+        if instance.spider.deleted:
+            return Response(
+                {"error": "Cannot run: spider no longer exists in the project."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         cronjob = SpiderCronJobSerializer(instance, partial=partial)
 

--- a/estela-api/api/views/job.py
+++ b/estela-api/api/views/job.py
@@ -54,7 +54,6 @@ class SpiderJobViewSet(
             .filter(
                 spider__project__pid=self.kwargs["pid"],
                 spider__sid=self.kwargs["sid"],
-                spider__deleted=False,
             )
         )
 

--- a/estela-api/core/cronjob.py
+++ b/estela-api/core/cronjob.py
@@ -46,7 +46,7 @@ def run_cronjob_once(data):
 
 def disable_cronjob(key):
     try:
-        cronjob = PeriodicTask.objects.get(name=key, enabled=True)
+        cronjob = PeriodicTask.objects.get(name=key)
         cronjob.enabled = False
         cronjob.save()
         return True
@@ -56,7 +56,7 @@ def disable_cronjob(key):
 
 def enable_cronjob(key):
     try:
-        cronjob = PeriodicTask.objects.get(name=key, enabled=False)
+        cronjob = PeriodicTask.objects.get(name=key)
         cronjob.enabled = True
         cronjob.save()
         return True

--- a/estela-api/core/signals.py
+++ b/estela-api/core/signals.py
@@ -1,10 +1,38 @@
+import logging
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from core.models import SpiderJob, UserProfile
+from core.cronjob import disable_cronjob
+from core.models import Spider, SpiderCronJob, SpiderJob, UserProfile
 from core.tasks import get_chain_to_process_usage_data, record_job_coverage_event
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_save, sender=Spider, dispatch_uid="disable_cronjobs_on_spider_delete")
+def disable_cronjobs_on_spider_delete(sender, instance, **kwargs):
+
+    if not instance.deleted:
+        return
+
+    cronjobs = list(instance.cronjobs.filter(deleted=False, status=SpiderCronJob.ACTIVE_STATUS))
+    if not cronjobs:
+        return
+
+    logger.info(
+        "Spider %s (sid=%s) marked deleted — disabling %d active cronjob(s)",
+        instance.name,
+        instance.sid,
+        len(cronjobs),
+    )
+    for cronjob in cronjobs:
+        disable_cronjob(cronjob.name)
+        cronjob.status = SpiderCronJob.DISABLED_STATUS
+        cronjob.save()
+    logger.info("Done disabling cronjobs for spider %s (sid=%s)", instance.name, instance.sid)
 
 
 @receiver(post_save, sender=User, dispatch_uid="create_user_profile")

--- a/estela-web/src/pages/CronJobDetailPage/index.tsx
+++ b/estela-web/src/pages/CronJobDetailPage/index.tsx
@@ -49,7 +49,13 @@ import {
     SpiderCronJobUpdate,
     SpiderCronJobUpdateDataStatusEnum,
 } from "../../services/api";
-import { resourceNotAllowedNotification, incorrectDataNotification, Spin, PaginationItem } from "../../shared";
+import {
+    resourceNotAllowedNotification,
+    incorrectDataNotification,
+    invalidDataNotification,
+    Spin,
+    PaginationItem,
+} from "../../shared";
 import { convertDateToString, getFilteredEnvVars } from "../../utils";
 import { DEFAULT_RESOURCE_TIER } from "../../constants";
 
@@ -509,8 +515,10 @@ export class CronJobDetailPage extends Component<RouteComponentProps<RouteParams
                 const jobs: SpiderJobData[] = data.data;
                 this.setState({ jobs: [...jobs] });
             },
-            (error: unknown) => {
-                error;
+            async (error: unknown) => {
+                const data = await (error as Response).json();
+                const msg = Array.isArray(data?.error) ? data.error[0] : data?.error;
+                msg ? invalidDataNotification(msg) : incorrectDataNotification();
             },
         );
     };
@@ -532,6 +540,7 @@ export class CronJobDetailPage extends Component<RouteComponentProps<RouteParams
             },
             (error: unknown) => {
                 error;
+                this.setState({ loading_status: false });
                 incorrectDataNotification();
             },
         );

--- a/estela-web/src/pages/ProjectCronJobListPage/index.tsx
+++ b/estela-web/src/pages/ProjectCronJobListPage/index.tsx
@@ -19,6 +19,7 @@ import {
 import {
     resourceNotAllowedNotification,
     incorrectDataNotification,
+    invalidDataNotification,
     Spin,
     PaginationItem,
     RouteParams,
@@ -274,9 +275,10 @@ export class ProjectCronJobListPage extends Component<RouteComponentProps<RouteP
                 message.success(`ScheduledJob ${response.cjid} ${response.status}`);
                 this.getCronJobs(this.state.page);
             },
-            (error: unknown) => {
-                error;
-                incorrectDataNotification();
+            async (error: unknown) => {
+                const data = await (error as Response).json();
+                const msg = Array.isArray(data?.error) ? data.error[0] : data?.error;
+                msg ? invalidDataNotification(msg) : incorrectDataNotification();
             },
         );
     };


### PR DESCRIPTION
# Summary
  

- Cronjobs are now automatically disabled when their spider is removed in a deploy. A Django signal on Spider.post_save detects the deleted=True transition and disables all active cronjobs for that spider (both SpiderCronJob.status and PeriodicTask.enabled).
- Orphaned cronjobs (whose spider was deleted) can now be managed from the UI — disabled, edited, or deleted. Previously the API returned 404 for any action on them.
- Attempting to re-enable a cronjob whose spider no longer exists now returns a clear error message instead of silently failing.
- Historical spider jobs from deleted spiders are now visible in the cronjob detail page.
- Fixed a silent failure in disable_cronjob / enable_cronjob where an inconsistent PeriodicTask state would cause the operation to silently do nothing.

# Issue

* _Github Issue ID_.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [ ] New and existing tests pass locally with my changes.
- [ ] If this change is a core feature, I have added thorough tests.
- [ ] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/).
- [ ] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
