### PR TITLE
Fix: masked env vars passed as literal string MASKED

### DIFF
--- a/estela-api/api/serializers/cronjob.py
+++ b/estela-api/api/serializers/cronjob.py
@@ -1,3 +1,5 @@
+import logging
+
 from croniter import croniter
 from rest_framework import serializers
 
@@ -15,6 +17,8 @@ from core.models import (
     SpiderJobEnvVar,
     SpiderJobTag,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class SpiderCronJobSerializer(serializers.ModelSerializer):
@@ -107,6 +111,22 @@ class SpiderCronJobCreateSerializer(serializers.ModelSerializer):
             SpiderJobArg.objects.create(cronjob=cronjob, **arg)
 
         for env_var in env_vars_data:
+            evid = env_var.pop("evid", None)
+            if evid:
+                source = SpiderJobEnvVar.objects.filter(evid=evid).first()
+                if source:
+                    SpiderJobEnvVar.objects.create(
+                        cronjob=cronjob,
+                        name=source.name,
+                        value=source.value,
+                        masked=source.masked,
+                    )
+                    continue
+                logger.warning(
+                    "evid=%s not found when creating env var '%s' for cronjob %s — skipping.",
+                    evid, env_var.get("name"), cronjob.cjid,
+                )
+                continue
             SpiderJobEnvVar.objects.create(cronjob=cronjob, **env_var)
 
         for tag_data in tags_data:

--- a/estela-api/api/serializers/job_specific.py
+++ b/estela-api/api/serializers/job_specific.py
@@ -10,6 +10,12 @@ class SpiderJobArgSerializer(serializers.ModelSerializer):
 
 
 class SpiderJobEnvVarSerializer(serializers.ModelSerializer):
+    evid = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        help_text="A unique integer value identifying this job env variable.",
+    )
+
     class Meta:
         model = SpiderJobEnvVar
         fields = ("evid", "name", "value", "masked")

--- a/estela-api/core/cronjob.py
+++ b/estela-api/core/cronjob.py
@@ -2,13 +2,14 @@ import json
 
 from django_celery_beat.models import CrontabSchedule, PeriodicTask
 
+from core.models import SpiderCronJob
 from core.tasks import launch_job
 
 
 def create_cronjob(name, key, args, env_vars, tags, schedule, data_expiry_days=None, resource_tier=None):
     minute, hour, day_of_month, month, day_of_week = schedule.split(" ")
     cjid, sid, pid = key.split(".")
-    data = {"cronjob": cjid, "args": args, "env_vars": env_vars, "tags": tags}
+    data = {"cronjob": cjid, "args": args, "env_vars": [], "tags": tags}
     if resource_tier:
         data["resource_tier"] = resource_tier
     schedule, _ = CrontabSchedule.objects.get_or_create(
@@ -28,8 +29,11 @@ def create_cronjob(name, key, args, env_vars, tags, schedule, data_expiry_days=N
 
 
 def run_cronjob_once(data):
-    env_vars = data.get("cenv_vars") or []
-    env_vars = [ev for ev in env_vars if ev.get("value") is not None]
+    cronjob = SpiderCronJob.objects.get(cjid=data.get("cjid"))
+    env_vars = [
+        {"name": ev.name, "value": ev.value, "masked": ev.masked}
+        for ev in cronjob.cenv_vars.all()
+    ]
     _data = {
         "cronjob": data.get("cjid"),
         "args": data.get("cargs"),

--- a/estela-api/core/tasks.py
+++ b/estela-api/core/tasks.py
@@ -25,6 +25,7 @@ from core.models import (
     Project,
     ProxyProvider,
     Spider,
+    SpiderCronJob,
     SpiderJob,
     UsageRecord,
 )
@@ -273,6 +274,18 @@ def launch_job(sid_, data_, data_expiry_days=None, token=None):
         data_["data_status"] = DataStatus.PENDING_STATUS
 
     resource_tier = data_.pop("resource_tier", None)
+
+    cjid = data_.get("cronjob")
+    if cjid:
+        cronjob = SpiderCronJob.objects.filter(cjid=cjid).first()
+        if cronjob:
+            cronjob_env_vars = {
+                ev.name: {"name": ev.name, "value": ev.value, "masked": ev.masked}
+                for ev in cronjob.cenv_vars.all()
+            }
+            extra_env_vars = {ev["name"]: ev for ev in data_.get("env_vars", [])}
+            cronjob_env_vars.update(extra_env_vars)
+            data_["env_vars"] = list(cronjob_env_vars.values())
 
     serializer = SpiderJobCreateSerializer(data=data_)
     serializer.is_valid(raise_exception=True)

--- a/estela-api/docs/api.yaml
+++ b/estela-api/docs/api.yaml
@@ -1886,7 +1886,7 @@ definitions:
         title: Evid
         description: A unique integer value identifying this job env variable.
         type: integer
-        readOnly: true
+        x-nullable: true
       name:
         title: Name
         description: Env variable name.

--- a/estela-web/src/pages/CronjobCreateModal/index.tsx
+++ b/estela-web/src/pages/CronjobCreateModal/index.tsx
@@ -87,6 +87,7 @@ interface ArgsData {
 }
 
 interface EnvVarsData {
+    evid?: number;
     name: string;
     value: string;
     key: number;
@@ -678,14 +679,20 @@ export default function CronjobCreateModal({ openModal, spider, projectId }: Cro
 
         cronjobData.envVars.map((envVar: EnvVarsData) => {
             const index = envVarsData.findIndex((element: SpiderJobEnvVar) => element.name === envVar.name);
+            const resolvedEvid =
+                envVar.masked && envVar.value === "__MASKED__"
+                    ? envVar.evid ?? (index !== -1 ? envVarsData[index].evid : undefined)
+                    : undefined;
             if (index != -1) {
                 envVarsData[index] = {
+                    evid: resolvedEvid,
                     name: envVar.name,
                     value: envVar.value,
                     masked: envVar.masked,
                 };
             } else {
                 envVarsData.push({
+                    evid: resolvedEvid,
                     name: envVar.name,
                     value: envVar.value,
                     masked: envVar.masked,

--- a/estela-web/src/pages/JobCreateModal/index.tsx
+++ b/estela-web/src/pages/JobCreateModal/index.tsx
@@ -48,6 +48,7 @@ interface ArgsData {
 }
 
 interface EnvVarsData {
+    evid?: number;
     name: string;
     value: string;
     key: number;
@@ -138,6 +139,7 @@ export default function JobCreateModal({
     const [jobData, setJobData] = useState<JobData>({
         args: initialArgs.map((arg, index) => ({ ...arg, key: index })),
         envVars: initialEnvVars.map((envVar, index) => ({
+            evid: envVar.evid,
             name: envVar.name,
             value: envVar.masked ? "__MASKED__" : envVar.value,
             masked: envVar.masked || false,
@@ -448,14 +450,20 @@ export default function JobCreateModal({
 
         jobData.envVars.map((envVar: EnvVarsData) => {
             const index = envVarsData.findIndex((element: SpiderJobEnvVar) => element.name === envVar.name);
+            const resolvedEvid =
+                envVar.masked && envVar.value === "__MASKED__"
+                    ? envVar.evid ?? (index !== -1 ? envVarsData[index].evid : undefined)
+                    : undefined;
             if (index != -1) {
                 envVarsData[index] = {
+                    evid: resolvedEvid,
                     name: envVar.name,
                     value: envVar.value,
                     masked: envVar.masked,
                 };
             } else {
                 envVarsData.push({
+                    evid: resolvedEvid,
                     name: envVar.name,
                     value: envVar.value,
                     masked: envVar.masked,

--- a/estela-web/src/services/api/generated-api/models/SpiderJobEnvVar.ts
+++ b/estela-web/src/services/api/generated-api/models/SpiderJobEnvVar.ts
@@ -24,7 +24,7 @@ export interface SpiderJobEnvVar {
      * @type {number}
      * @memberof SpiderJobEnvVar
      */
-    readonly evid?: number;
+    evid?: number | null;
     /**
      * Env variable name.
      * @type {string}
@@ -71,6 +71,7 @@ export function SpiderJobEnvVarToJSON(value?: SpiderJobEnvVar | null): any {
     }
     return {
         
+        'evid': value.evid,
         'name': value.name,
         'value': value.value,
         'masked': value.masked,


### PR DESCRIPTION
# Description

Fixes a bug where masked environment variables were stored as the literal string "__MASKED__" in the database instead of the real value, causing spiders to receive "__MASKED__" at runtime.

# Issue

* _Github Issue ID_.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [ ] New and existing tests pass locally with my changes.
- [ ] If this change is a core feature, I have added thorough tests.
- [ ] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/).
- [ ] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
