### PR TITLE
Fix: disable DEBUG in non-local environments

### DIFF
--- a/estela-api/config/settings/base.py
+++ b/estela-api/config/settings/base.py
@@ -121,6 +121,7 @@ INSTALLED_APPS = DEFAULT_APPS + THIRD_PARTY_APPS + PROJECT_APPS + DJANGO_EXTERNA
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/estela-api/config/settings/local.py
+++ b/estela-api/config/settings/local.py
@@ -1,6 +1,8 @@
+import environ as _environ
+
 from config.settings.base import *  # noqa: F401,F403,F405
 
-DEBUG = True
+DEBUG = _environ.Env().bool("DEBUG", default=False)
 
 RUN_JOBS_PER_LOT = 100
 CHECK_JOB_ERRORS_BATCH_SIZE = 10

--- a/estela-api/config/urls.py
+++ b/estela-api/config/urls.py
@@ -39,5 +39,4 @@ urlpatterns = [
 ]
 urlpatterns = urlpatterns + django_external_apps_url
 
-if settings.DEBUG:
-    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/estela-api/requirements/base.in
+++ b/estela-api/requirements/base.in
@@ -19,4 +19,5 @@ pymongo[srv]
 pyodbc
 redis
 gunicorn
+whitenoise
 git+https://github.com/bitmakerla/estela-queue-adapter.git

--- a/estela-api/requirements/base.txt
+++ b/estela-api/requirements/base.txt
@@ -116,6 +116,7 @@ google-resumable-media==2.5.0
 googleapis-common-protos==1.60.0
     # via google-api-core
 gunicorn==20.1.0
+whitenoise==6.7.0
     # via -r base.in
 idna==2.10
     # via requests

--- a/estela-api/requirements/test.txt
+++ b/estela-api/requirements/test.txt
@@ -165,6 +165,7 @@ googleapis-common-protos==1.60.0
     #   -r base.txt
     #   google-api-core
 gunicorn==20.1.0
+whitenoise==6.7.0
     # via -r base.txt
 idna==2.10
     # via


### PR DESCRIPTION
# Description

`DEBUG=True` was hardcoded in `config.settings.local`, which all environments use. This exposed all URL patterns on 404 pages and served static files only through Django's dev server helper.
# Issue

* _Github Issue ID_.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [ ] New and existing tests pass locally with my changes.
- [ ] If this change is a core feature, I have added thorough tests.
- [ ] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/).
- [ ] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
