### PR TITLE
fix: exclude storage_size from job list serializer

### DIFF
--- a/estela-api/api/serializers/job.py
+++ b/estela-api/api/serializers/job.py
@@ -39,7 +39,6 @@ class SpiderJobSerializer(serializers.ModelSerializer):
         required=False, read_only=True, help_text="Current job status."
     )
     spider = serializers.SerializerMethodField("get_spider")
-    storage_size = serializers.SerializerMethodField("get_storage_size")
     database_insertion_progress = serializers.SerializerMethodField("get_database_insertion_progress")
     peak_memory = serializers.SerializerMethodField("get_peak_memory")
 
@@ -62,29 +61,12 @@ class SpiderJobSerializer(serializers.ModelSerializer):
             "data_expiry_days",
             "data_status",
             "database_insertion_progress",
-            "storage_size",
             "resource_tier",
             "peak_memory",
         )
 
     def get_spider(self, instance):
         return {"sid": instance.spider.sid, "name": instance.spider.name}
-
-    def get_storage_size(self, instance):
-        if not spiderdata_db_client.get_connection():
-            raise DataBaseError({"error": errors.UNABLE_CONNECT_DB})
-
-        pid = str(instance.spider.project.pid)
-        collections = ["items", "requests", "logs"]
-        total_size = sum(
-            [
-                spiderdata_db_client.get_dataset_size(
-                    pid, get_collection_name(instance, collection)
-                )
-                for collection in collections
-            ]
-        )
-        return total_size
 
     def get_database_insertion_progress(self, instance):
         # Return the actual database insertion progress value from the model
@@ -120,6 +102,29 @@ class SpiderJobSerializer(serializers.ModelSerializer):
             except Exception:
                 pass
         return None
+
+
+class SpiderJobDetailSerializer(SpiderJobSerializer):
+    storage_size = serializers.SerializerMethodField("get_storage_size")
+
+    class Meta(SpiderJobSerializer.Meta):
+        fields = SpiderJobSerializer.Meta.fields + ("storage_size",)
+
+    def get_storage_size(self, instance):
+        if not spiderdata_db_client.get_connection():
+            raise DataBaseError({"error": errors.UNABLE_CONNECT_DB})
+
+        pid = str(instance.spider.project.pid)
+        collections = ["items", "requests", "logs"]
+        total_size = sum(
+            [
+                spiderdata_db_client.get_dataset_size(
+                    pid, get_collection_name(instance, collection)
+                )
+                for collection in collections
+            ]
+        )
+        return total_size
 
 
 class SpiderJobCreateEnvVarSerializer(serializers.Serializer):

--- a/estela-api/api/views/job.py
+++ b/estela-api/api/views/job.py
@@ -11,6 +11,7 @@ from api.filters import SpiderJobFilter
 from api.mixins import ActionHandlerMixin, BaseViewSet
 from api.serializers.job import (
     SpiderJobCreateSerializer,
+    SpiderJobDetailSerializer,
     SpiderJobSerializer,
     SpiderJobUpdateSerializer,
 )
@@ -196,7 +197,7 @@ class SpiderJobViewSet(
         if job.status == SpiderJob.RUNNING_STATUS:
             update_stats_from_redis(job)
 
-        serializer = SpiderJobSerializer(job)
+        serializer = SpiderJobDetailSerializer(job)
 
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_200_OK, headers=headers)


### PR DESCRIPTION
# Description

- Remove storage_size calculation from SpiderJobSerializer (used in list endpoints)
- Add SpiderJobDetailSerializer that includes storage_size, used only in job retrieve
- Prevents collStats being called N×3 times per list request, which was exhausting MongoDB file descriptors with 30k+ collections

# Issue

* _Github Issue ID_.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [ ] New and existing tests pass locally with my changes.
- [ ] If this change is a core feature, I have added thorough tests.
- [ ] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/).
- [ ] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
